### PR TITLE
Bump deps

### DIFF
--- a/packages/bootloader/package.json
+++ b/packages/bootloader/package.json
@@ -5,7 +5,7 @@
     "generate-patchwork-bootloader": "./dist/generate.js"
   },
   "devDependencies": {
-    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.58",
+    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.60",
     "@keyhive/keyhive": "0.0.0-alpha.36",
     "esbuild": "^0.23.1"
   },
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@automerge/automerge": "3.0.0",
-    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.58",
+    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.60",
     "@automerge/automerge-repo": "2.4.0-alpha.2",
     "@automerge/vanillajs": "2.4.0-alpha.2",
     "@keyhive/keyhive": "0.0.0-alpha.24"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.58",
+    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.60",
     "@keyhive/keyhive": "0.0.0-alpha.36"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,8 @@ importers:
         version: 0.1.4
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.60
+        version: 0.0.0-alpha.60
       '@keyhive/keyhive':
         specifier: 0.0.0-alpha.36
         version: 0.0.0-alpha.36
@@ -154,8 +154,8 @@ importers:
   packages/identity:
     dependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.60
+        version: 0.0.0-alpha.60
       '@keyhive/keyhive':
         specifier: 0.0.0-alpha.36
         version: 0.0.0-alpha.36
@@ -259,8 +259,8 @@ importers:
         specifier: 2.4.0-alpha.2
         version: 2.4.0-alpha.2
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.60
+        version: 0.0.0-alpha.60
       '@automerge/vanillajs':
         specifier: 2.4.0-alpha.2
         version: 2.4.0-alpha.2
@@ -305,8 +305,8 @@ importers:
         specifier: 2.4.0-alpha.2
         version: 2.4.0-alpha.2
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.60
+        version: 0.0.0-alpha.60
       '@automerge/automerge-repo-react-hooks':
         specifier: ^2.4.0-alpha.2
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -428,8 +428,8 @@ packages:
   '@automerge/automerge-codemirror@0.2.0':
     resolution: {integrity: sha512-GBNh4ESZHFNHZKLznf/2G2KdmBD+unEdk64+l621LsjIsJs6HBmQmO8RCY1v7vIq31kFyoVHNcBMGQOnLgy4GA==}
 
-  '@automerge/automerge-repo-keyhive@0.0.0-alpha.58':
-    resolution: {integrity: sha512-8b9zfbcgukEgFCxqow8rzKYXpIB1LQABM+Vn1hllrIdxXtDc3MyZ3scIPqwovqphiLljtVj/nTeyY4HQiwBR4A==}
+  '@automerge/automerge-repo-keyhive@0.0.0-alpha.60':
+    resolution: {integrity: sha512-Cqe0zNotNH0ci1BO2fOQtHDuhLY/wwPCujMNZkXWVsWzSDz9Dp/TGz2G3nMbx0bUvlWzrUC5NjEgJ1kNggypkw==}
 
   '@automerge/automerge-repo-network-broadcastchannel@2.4.0-alpha.2':
     resolution: {integrity: sha512-l3VJomRii8T7jZD9kmJ0vXO3c/Usnir6y2DoO5t4nlxIU9cikf/pr0FaJp8p3RyZOwe2aACrzTPbJnU9KAXRYA==}
@@ -2669,7 +2669,7 @@ snapshots:
       '@codemirror/view': 6.38.6
       codemirror: 6.0.2
 
-  '@automerge/automerge-repo-keyhive@0.0.0-alpha.58':
+  '@automerge/automerge-repo-keyhive@0.0.0-alpha.60':
     dependencies:
       '@automerge/automerge-repo': 2.4.0-alpha.2
       '@automerge/automerge-repo-network-websocket': 2.4.0-alpha.2

--- a/sites/hive/package.json
+++ b/sites/hive/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.58",
+    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.60",
     "@keyhive/keyhive": "0.0.0-alpha.36",
     "@automerge/automerge": "3.0.0",
     "@automerge/automerge-repo": "2.4.0-alpha.2",

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@automerge/automerge": "3.0.0",
     "@automerge/automerge-codemirror": "^0.2.0",
-    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.58",
+    "@automerge/automerge-repo-keyhive": "0.0.0-alpha.60",
     "@automerge/automerge-repo": "^2.4.0-alpha.2",
     "@automerge/automerge-repo-react-hooks": "^2.4.0-alpha.2",
     "@automerge/vanillajs": "^2.4.0-alpha.2",


### PR DESCRIPTION
The latest `automerge-repo-keyhive` supports much faster page loading.