### PR TITLE
Update names of docs in sidebar & add new documents 

### DIFF
--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -39,6 +39,7 @@
     "@automerge/automerge": "catalog:",
     "@automerge/automerge-repo": "catalog:",
     "@automerge/automerge-repo-react-hooks": "catalog:",
+    "@patchwork/filesystem": "workspace:*",
     "eventemitter3": "^5.0.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.1"

--- a/packages/context/src/apis/selection.ts
+++ b/packages/context/src/apis/selection.ts
@@ -3,6 +3,7 @@ import { defineField } from "../core/fields";
 import { Ref } from "../core/refs";
 import { contextComputation } from "../core/computation";
 import { Reactive } from "../reactive";
+import { AutomergeUrl } from "@automerge/automerge-repo";
 
 const IsSelectedSymbol = Symbol("IsSelected");
 export type IsSelected = typeof IsSelectedSymbol;
@@ -17,3 +18,14 @@ export const isSelected = (ref: Ref): Reactive<boolean> =>
 export const $selectedRefs = contextComputation(() =>
   CONTEXT.refsWith(IsSelected).filter((ref) => ref.get(IsSelected) === true)
 );
+
+export const $selectedDocUrls = contextComputation((context) => {
+  const selectedRefs = context.refsWith(IsSelected);
+  const selectedDocUrls = new Set<AutomergeUrl>();
+
+  for (const ref of selectedRefs) {
+    selectedDocUrls.add(ref.docUrl);
+  }
+
+  return Array.from(selectedDocUrls);
+});

--- a/packages/context/src/apis/selection.ts
+++ b/packages/context/src/apis/selection.ts
@@ -3,7 +3,8 @@ import { defineField } from "../core/fields";
 import { Ref } from "../core/refs";
 import { contextComputation } from "../core/computation";
 import { Reactive } from "../reactive";
-import { AutomergeUrl } from "@automerge/automerge-repo";
+import { AutomergeUrl, DocHandle } from "@automerge/automerge-repo";
+import { HasPatchworkMetadata } from "@patchwork/filesystem";
 
 const IsSelectedSymbol = Symbol("IsSelected");
 export type IsSelected = typeof IsSelectedSymbol;
@@ -28,4 +29,15 @@ export const $selectedDocUrls = contextComputation((context) => {
   }
 
   return Array.from(selectedDocUrls);
+});
+
+export const $selectedDocHandles = contextComputation((context) => {
+  const selectedRefs = context.refsWith(IsSelected);
+  const selectedDocs = new Set<DocHandle<HasPatchworkMetadata>>();
+
+  for (const ref of selectedRefs) {
+    selectedDocs.add(ref.docHandle as DocHandle<HasPatchworkMetadata>);
+  }
+
+  return Array.from(selectedDocs);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@automerge/automerge-repo-react-hooks':
         specifier: 'catalog:'
         version: 2.5.0-alpha.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@patchwork/filesystem':
+        specifier: workspace:*
+        version: link:../filesystem
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1

--- a/sites/tiny-patchwork/src/tools/history-view/HistoryView.tsx
+++ b/sites/tiny-patchwork/src/tools/history-view/HistoryView.tsx
@@ -1,19 +1,18 @@
 import * as Automerge from "@automerge/automerge";
 import { AutomergeUrl } from "@automerge/automerge-repo";
 import { useDocument, useRepo } from "@automerge/automerge-repo-react-hooks";
-import { CONTEXT, contextComputation } from "@patchwork/context";
 import { ViewHeads, ViewHeadsValue } from "@patchwork/context/diff";
 import {
   useDocRef,
   useReactive,
   useSubcontext,
 } from "@patchwork/context/react";
-import { IsSelected } from "@patchwork/context/selection";
 import { HasPatchworkMetadata } from "@patchwork/filesystem";
 import { useEffect, useState } from "react";
 import { useTitle } from "../../lib/datatype-hooks";
 import { relativeTime } from "../../lib/relative-time";
 import { toolify } from "../../lib/toolify";
+import { $selectedDocUrls } from "@patchwork/context/selection";
 
 const HistoryView = () => {
   const selectedDocUrls = useReactive($selectedDocUrls);
@@ -131,17 +130,5 @@ const DocHistoryView = ({ docUrl }: { docUrl: AutomergeUrl }) => {
     </div>
   );
 };
-
-const $selectedDocUrls = contextComputation((context) => {
-  const selectedRefs = context.refsWith(IsSelected);
-
-  const selectedDocUrls = new Set<AutomergeUrl>();
-
-  for (const ref of selectedRefs) {
-    selectedDocUrls.add(ref.docUrl);
-  }
-
-  return Array.from(selectedDocUrls);
-});
 
 export const renderHistoryView = toolify(HistoryView);

--- a/sites/tiny-patchwork/src/tools/patchwork-frame/PatchworkFrame.tsx
+++ b/sites/tiny-patchwork/src/tools/patchwork-frame/PatchworkFrame.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { TinyPatchworkAccountDoc } from "../../lib/account-doc";
 import { openDocument } from "../../lib/navigation";
 import { toolify } from "../../lib/toolify";
+import { useUpdateDocLinksOfActiveDocumentsEffect } from "./effects";
 
 export const renderFrame = toolify(
   ({
@@ -28,6 +29,9 @@ export const renderFrame = toolify(
     );
 
     const repo = useRepo();
+
+    // update doc links of active documents
+    useUpdateDocLinksOfActiveDocumentsEffect(rootFolderUrl);
 
     // listen to open document events
     useEffect(() => {

--- a/sites/tiny-patchwork/src/tools/patchwork-frame/PatchworkFrame.tsx
+++ b/sites/tiny-patchwork/src/tools/patchwork-frame/PatchworkFrame.tsx
@@ -4,7 +4,10 @@ import { useEffect, useState } from "react";
 import { TinyPatchworkAccountDoc } from "../../lib/account-doc";
 import { openDocument } from "../../lib/navigation";
 import { toolify } from "../../lib/toolify";
-import { useUpdateDocLinksOfActiveDocumentsEffect } from "./effects";
+import {
+  useAddUnknownDocumentsToSidebarEffect,
+  useUpdateDocLinksOfActiveDocumentsEffect,
+} from "./effects";
 
 export const renderFrame = toolify(
   ({
@@ -30,8 +33,11 @@ export const renderFrame = toolify(
 
     const repo = useRepo();
 
-    // update doc links of active documents
+    // Effects
+    // this should be probably a plugin type that allows to run code without rendering something
+
     useUpdateDocLinksOfActiveDocumentsEffect(rootFolderUrl);
+    useAddUnknownDocumentsToSidebarEffect(rootFolderUrl);
 
     // listen to open document events
     useEffect(() => {

--- a/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
+++ b/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
@@ -52,8 +52,6 @@ export const useUpdateDocLinksOfActiveDocumentsEffect = (
         continue;
       }
 
-      console.log("check", docUrl, type);
-
       registry.loadById(type).then((datatype) => {
         if (canceled || !datatype) {
           return;
@@ -109,25 +107,16 @@ export const useAddUnknownDocumentsToSidebarEffect = (
         }
 
         const title = datatype.module.getTitle(docHandle.doc());
+        if (rootFolderDoc.docs.some((doc) => doc.url === docHandle.url)) {
+          return;
+        }
 
         changeRootFolderDoc((rootFolderDoc) => {
-          if (rootFolderDoc.docs.some((doc) => doc.url === docHandle.url)) {
-            return;
-          }
-
-          const docLink = {
+          rootFolderDoc.docs[rootFolderDoc.docs.length] = {
             name: title,
             url: docHandle.url,
             type: type,
           };
-
-          console.log("add", docLink);
-
-          rootFolderDoc.docs.push({
-            name: title,
-            url: docHandle.url,
-            type: type,
-          });
         });
       });
     }

--- a/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
+++ b/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
@@ -4,7 +4,10 @@ import {
   useDocuments,
 } from "@automerge/automerge-repo-react-hooks";
 import { useReactive } from "@patchwork/context/react";
-import { $selectedDocUrls } from "@patchwork/context/selection";
+import {
+  $selectedDocHandles,
+  $selectedDocUrls,
+} from "@patchwork/context/selection";
 import { FolderDoc, HasPatchworkMetadata } from "@patchwork/filesystem";
 import {
   DataTypeDescription,
@@ -72,4 +75,65 @@ export const useUpdateDocLinksOfActiveDocumentsEffect = (
       canceled = true;
     };
   }, [changeRootFolderDoc, rootFolderDoc, selectedDocUrls, selectedDocsMap]);
+};
+
+export const useAddUnknownDocumentsToSidebarEffect = (
+  rootFolderUrl: AutomergeUrl
+) => {
+  const selectedDocHandles = useReactive($selectedDocHandles);
+  const [rootFolderDoc, changeRootFolderDoc] =
+    useDocument<FolderDoc>(rootFolderUrl);
+
+  useEffect(() => {
+    if (!rootFolderDoc) {
+      return;
+    }
+
+    let canceled = false;
+
+    const registry = getPluginRegistry("patchwork:datatype") as PluginRegistry<
+      DataTypeDescription,
+      DataTypeImplementation
+    >;
+
+    for (const docHandle of selectedDocHandles) {
+      const type = docHandle.doc()["@patchwork"]?.type;
+
+      if (!type) {
+        continue;
+      }
+
+      registry.loadById(type).then((datatype) => {
+        if (canceled || !datatype) {
+          return;
+        }
+
+        const title = datatype.module.getTitle(docHandle.doc());
+
+        changeRootFolderDoc((rootFolderDoc) => {
+          if (rootFolderDoc.docs.some((doc) => doc.url === docHandle.url)) {
+            return;
+          }
+
+          const docLink = {
+            name: title,
+            url: docHandle.url,
+            type: type,
+          };
+
+          console.log("add", docLink);
+
+          rootFolderDoc.docs.push({
+            name: title,
+            url: docHandle.url,
+            type: type,
+          });
+        });
+      });
+    }
+
+    return () => {
+      canceled = true;
+    };
+  }, [changeRootFolderDoc, rootFolderDoc, selectedDocHandles]);
 };

--- a/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
+++ b/sites/tiny-patchwork/src/tools/patchwork-frame/effects.ts
@@ -1,0 +1,75 @@
+import { AutomergeUrl } from "@automerge/automerge-repo";
+import {
+  useDocument,
+  useDocuments,
+} from "@automerge/automerge-repo-react-hooks";
+import { useReactive } from "@patchwork/context/react";
+import { $selectedDocUrls } from "@patchwork/context/selection";
+import { FolderDoc, HasPatchworkMetadata } from "@patchwork/filesystem";
+import {
+  DataTypeDescription,
+  DataTypeImplementation,
+  getPluginRegistry,
+} from "@patchwork/plugins";
+import { PluginRegistry } from "@patchwork/plugins/dist/registry/registry";
+import { useEffect } from "react";
+
+export const useUpdateDocLinksOfActiveDocumentsEffect = (
+  rootFolderUrl: AutomergeUrl
+) => {
+  const selectedDocUrls = useReactive($selectedDocUrls);
+  const [selectedDocsMap] = useDocuments<HasPatchworkMetadata>(selectedDocUrls);
+
+  // todo: handle folders
+  const [rootFolderDoc, changeRootFolderDoc] = useDocument<FolderDoc>(
+    rootFolderUrl,
+    {
+      suspense: true,
+    }
+  );
+
+  useEffect(() => {
+    let canceled = false;
+
+    const registry = getPluginRegistry("patchwork:datatype") as PluginRegistry<
+      DataTypeDescription,
+      DataTypeImplementation
+    >;
+
+    for (const docUrl of selectedDocUrls) {
+      const doc = selectedDocsMap.get(docUrl);
+
+      if (!doc) {
+        continue;
+      }
+
+      const type = doc["@patchwork"]?.type;
+
+      if (!type) {
+        continue;
+      }
+
+      console.log("check", docUrl, type);
+
+      registry.loadById(type).then((datatype) => {
+        if (canceled || !datatype) {
+          return;
+        }
+
+        const title = datatype.module.getTitle(doc);
+
+        changeRootFolderDoc((doc) => {
+          for (const docLink of doc.docs) {
+            if (docLink.url === docUrl && docLink.name !== title) {
+              docLink.name = title;
+            }
+          }
+        });
+      });
+    }
+
+    return () => {
+      canceled = true;
+    };
+  }, [changeRootFolderDoc, rootFolderDoc, selectedDocUrls, selectedDocsMap]);
+};

--- a/sites/tiny-patchwork/src/tools/single-view/SingleView.tsx
+++ b/sites/tiny-patchwork/src/tools/single-view/SingleView.tsx
@@ -24,7 +24,7 @@ import {
 import { IsSelected } from "@patchwork/context/selection";
 import { HasPatchworkMetadata } from "@patchwork/filesystem";
 import { ToolElement } from "@patchwork/plugins";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTitle } from "../../lib/datatype-hooks";
 import { openDocument, OpenDocumentEvent } from "../../lib/navigation";
 import { toolify } from "../../lib/toolify";

--- a/sites/tiny-patchwork/src/tools/single-view/SingleView.tsx
+++ b/sites/tiny-patchwork/src/tools/single-view/SingleView.tsx
@@ -24,7 +24,7 @@ import {
 import { IsSelected } from "@patchwork/context/selection";
 import { HasPatchworkMetadata } from "@patchwork/filesystem";
 import { ToolElement } from "@patchwork/plugins";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTitle } from "../../lib/datatype-hooks";
 import { openDocument, OpenDocumentEvent } from "../../lib/navigation";
 import { toolify } from "../../lib/toolify";
@@ -42,7 +42,11 @@ const SingleView = ({
     { suspense: true }
   );
 
-  const { selection, highlightChanges } = singleViewDoc;
+  const { highlightChanges } = singleViewDoc;
+
+  const [selection, setSelection] = useState<
+    { url: AutomergeUrl; toolId?: string } | undefined
+  >(undefined);
 
   const currentDocRef = useDocRef(selection?.url);
 
@@ -120,14 +124,7 @@ const SingleView = ({
         const { url, toolId } = event.detail;
         console.log("single view: handle open document event", event);
 
-        changeSingleViewDoc((doc) => {
-          // Simply replace the current document
-          doc.selection = { url };
-
-          if (toolId) {
-            doc.selection.toolId = toolId;
-          }
-        });
+        setSelection({ url, toolId });
       };
 
       (element as HTMLElement).addEventListener(
@@ -141,7 +138,7 @@ const SingleView = ({
         );
       };
     }
-  }, [changeSingleViewDoc, element]);
+  }, [element, setSelection]);
 
   // add doc handle to window
   useEffect(() => {

--- a/sites/tiny-patchwork/src/tools/single-view/datatype.ts
+++ b/sites/tiny-patchwork/src/tools/single-view/datatype.ts
@@ -2,13 +2,11 @@ import { DataTypeImplementation } from "@patchwork/plugins";
 import type { AutomergeUrl } from "@automerge/vanillajs";
 
 export interface SingleViewDoc {
-  selection?: { url: AutomergeUrl; toolId?: string };
   highlightChanges: boolean;
 }
 
 export const SingleViewDataType: DataTypeImplementation<SingleViewDoc> = {
   init: (doc: SingleViewDoc) => {
-    doc.selection = undefined;
     doc.highlightChanges = false;
   },
   getTitle() {

--- a/sites/tiny-patchwork/src/tools/todo/Todo.tsx
+++ b/sites/tiny-patchwork/src/tools/todo/Todo.tsx
@@ -38,6 +38,12 @@ export const TodoEditor = ({ docUrl }: ReactToolProps) => {
     setText("");
   };
 
+  const setTitle = (title: string) => {
+    changeDoc((doc) => {
+      doc.title = title;
+    });
+  };
+
   // hack: ignore
   if (
     !docHandle ||
@@ -53,7 +59,15 @@ export const TodoEditor = ({ docUrl }: ReactToolProps) => {
   return (
     <div className="p-4  h-full">
       <div className="max-w-[400px] mx-auto flex flex-col gap-2 bg-white rounded-md p-4">
-        <div className="text-2xl font-bold">{doc.title}</div>
+        <div className="text-2xl font-bold">
+          <input
+            type="text"
+            value={doc.title}
+            className="w-full"
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Untitled"
+          />
+        </div>
         <div className="flex gap-2">
           <input
             type="text"


### PR DESCRIPTION
This PR add some small quality of life improvements:

- file names update in the sidebar if the title of the document changes
- new documents are added to the sidebar

This doesn't handle nested folders yet we should extend this once we actually have nested folder. Eventually we should add a proper system that allows you to register effects like that as plugins