### PR TITLE
fix: add solid-js to vite config to avoid conflicts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       signia:
         specifier: ^0.1.5
         version: 0.1.5
+      solid-js:
+        specifier: ^1.9.9
+        version: 1.9.9
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.15

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^18.0.0",
     "scheduler": "^0.27.0",
     "signia": "^0.1.5",
+    "solid-js": "^1.9.9",
     "tailwindcss": "^4.1.14",
     "tldraw": "^4.1.1"
   }

--- a/sites/tiny-patchwork/vite.config.ts
+++ b/sites/tiny-patchwork/vite.config.ts
@@ -24,7 +24,6 @@ export default defineConfig({
         "@patchwork/context/comments":
           "/packages/@patchwork/context/comments.js",
         "@patchwork/filesystem": "/packages/@patchwork/filesystem/index.js",
-
         "@automerge/automerge-repo-react-hooks":
           "/packages/@automerge/automerge-repo-react-hooks/index.js",
         react: "/packages/react/index.js",
@@ -34,6 +33,11 @@ export default defineConfig({
         "react-dom/server": "/packages/react-dom/server.js",
         signia: "/packages/signia/index.js",
         scheduler: "/packages/scheduler/index.js",
+        "solid-js": "/packages/solid-js/index.js",
+        "solid-js/store": "/packages/solid-js/store.js",
+        "solid-js/html": "/packages/solid-js/html.js",
+        "solid-js/h": "/packages/solid-js/h.js",
+        "solid-js/web": "/packages/solid-js/web.js"
       },
       importmap: {
         imports: {


### PR DESCRIPTION
This fixes a warning that was occurring when using `createReactive` or `createSubcontext` from`packages/context/src/frameworks/solid.ts` in an external tool (i.e. defined outside of tiny-patchwork), which stated that "computations created outside a `createRoot` or `render` will never be disposed" and "cleanups created outside a `createRoot` or `render` will never be run".