### PR TITLE
simple 'view source' view

### DIFF
--- a/tools/sideboard/src/index.css
+++ b/tools/sideboard/src/index.css
@@ -415,3 +415,302 @@
   animation: hello alternate-reverse infinite 2s;
   color: black;
 }
+
+.view-source__button {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 0.5em 1em;
+  cursor: pointer;
+  font-weight: 500;
+  color: #333;
+  transition: all 0.15s ease;
+  margin-top: 1em;
+  font-size: 0.9em;
+}
+
+.view-source__button:hover {
+  background: #f5f5f5;
+  border-color: #999;
+}
+
+.view-source__modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.view-source__modal-content {
+  background: white;
+  border-radius: 8px;
+  width: 90vw;
+  max-width: 1400px;
+  height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.view-source__modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25em 1.5em;
+  border-bottom: 1px solid #e8e8e8;
+  background: #fafafa;
+}
+
+.view-source__modal-header h2 {
+  margin: 0;
+  color: #222;
+  font-size: 1.1em;
+  font-weight: 600;
+}
+
+.view-source__close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5em;
+  color: #666;
+  width: 2em;
+  height: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+  border-radius: 4px;
+}
+
+.view-source__close:hover {
+  background: #eee;
+  color: #222;
+}
+
+.view-source__loading,
+.view-source__error,
+.view-source__empty {
+  padding: 2em;
+  text-align: center;
+  color: #666;
+  font-size: 1.1em;
+}
+
+.view-source__error {
+  color: #d00;
+  background: #fee;
+  border-radius: 4px;
+  margin: 2em;
+}
+
+.view-source__layout {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.view-source__empty-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-size: 1.2em;
+  font-style: italic;
+}
+
+.view-source__file-list {
+  border-right: 1px solid #e8e8e8;
+  padding: 1em;
+  overflow-y: auto;
+  background: #fafafa;
+}
+
+.view-source__file-list h4 {
+  margin: 0 0 0.75em 0;
+  color: #666;
+  font-size: 0.75em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 0 0.5em;
+}
+
+.view-source__file-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 0.6em 0.75em;
+  margin-bottom: 0.25em;
+  cursor: pointer;
+  font-size: 0.85em;
+  color: #555;
+  transition: all 0.15s ease;
+  word-break: break-all;
+  font-family: "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
+}
+
+.view-source__file-item:hover {
+  background: #f0f0f0;
+  color: #222;
+}
+
+.view-source__file-item--selected {
+  background: #e8e8e8;
+  color: #000;
+  font-weight: 500;
+}
+
+.view-source__file-preview {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5em;
+  background: white;
+}
+
+.view-source__file-preview h4 {
+  margin: 0 0 0.5em 0;
+  color: #222;
+  font-size: 1em;
+  font-weight: 600;
+}
+
+.view-source__file-meta {
+  margin-bottom: 1em;
+  color: #888;
+  font-size: 0.8em;
+  padding-bottom: 1em;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.view-source__file-meta code {
+  background: #f5f5f5;
+  padding: 0.25em 0.5em;
+  border-radius: 3px;
+  font-family: "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
+  font-size: 0.9em;
+  color: #555;
+}
+
+.view-source__code {
+  margin: 0;
+  padding: 1.25em;
+  background: #f8f9fa;
+  border: 1px solid #e8e8e8;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 0.875em;
+  line-height: 1.6;
+  color: #24292e;
+  flex: 1;
+}
+
+.view-source__code code {
+  font-family: "SF Mono", "Monaco", "Menlo", "Consolas", monospace;
+  white-space: pre;
+  color: #24292e;
+}
+
+@media (prefers-color-scheme: dark) {
+  .view-source__button {
+    background: #2a2a2a;
+    border-color: #404040;
+    color: #e0e0e0;
+  }
+
+  .view-source__button:hover {
+    background: #333;
+    border-color: #555;
+  }
+
+  .view-source__modal-content {
+    background: #1e1e1e;
+  }
+
+  .view-source__modal-header {
+    background: #252525;
+    border-bottom-color: #333;
+  }
+
+  .view-source__modal-header h2 {
+    color: #e0e0e0;
+  }
+
+  .view-source__close {
+    color: #999;
+  }
+
+  .view-source__close:hover {
+    background: #333;
+    color: #e0e0e0;
+  }
+
+  .view-source__file-list {
+    background: #1a1a1a;
+    border-right-color: #333;
+  }
+
+  .view-source__file-list h4 {
+    color: #888;
+  }
+
+  .view-source__file-preview h4 {
+    color: #e0e0e0;
+  }
+
+  .view-source__file-preview {
+    background: #1e1e1e;
+  }
+
+  .view-source__file-item {
+    color: #aaa;
+  }
+
+  .view-source__file-item:hover {
+    background: #252525;
+    color: #e0e0e0;
+  }
+
+  .view-source__file-item--selected {
+    background: #2a2a2a;
+    color: #fff;
+  }
+
+  .view-source__file-meta {
+    color: #888;
+    border-bottom-color: #2a2a2a;
+  }
+
+  .view-source__file-meta code {
+    background: #2a2a2a;
+    color: #aaa;
+  }
+
+  .view-source__code {
+    background: #0d1117;
+    border-color: #30363d;
+    color: #c9d1d9;
+  }
+
+  .view-source__code code {
+    color: #c9d1d9;
+  }
+
+  .view-source__empty-preview {
+    color: #666;
+  }
+}

--- a/tools/sideboard/src/module-settings/module-settings.tsx
+++ b/tools/sideboard/src/module-settings/module-settings.tsx
@@ -2,23 +2,14 @@ import {
   createSignal,
   For,
   Suspense,
-  onCleanup,
   createEffect,
-  createResource,
   type Signal,
-  type Resource,
   Show,
 } from "solid-js";
 import html from "solid-js/html";
 import { createStore, unwrap, reconcile } from "solid-js/store";
 import { makeDocumentProjection } from "@automerge/automerge-repo-solid-primitives";
-
-import {
-  getPluginRegistry,
-  getLoadedPlugins,
-  type Tool,
-  getPlugins,
-} from "@patchwork/plugins";
+import { getPluginRegistry } from "@patchwork/plugins";
 import {
   isValidAutomergeUrl,
   type AutomergeUrl,
@@ -26,6 +17,8 @@ import {
 import type { ModuleSettingsDoc } from "@patchwork/filesystem";
 import type { PatchworkToolProps } from "../types.ts";
 import { useTools } from "../sideboard/plugins.ts";
+import { ViewSource } from "./view-source.tsx";
+
 const registry = getPluginRegistry("patchwork:tool");
 
 function swapWithEnd(list: any[], idx: number) {
@@ -138,6 +131,12 @@ export function ModuleSettings(props: PatchworkToolProps<ModuleSettingsDoc>) {
                       {(dt) => html`<li>${() => dt}</li>`}
                     </For>
                   </ul>
+                  <Show when={isValidAutomergeUrl(tool.importUrl)}>
+                    <ViewSource
+                      moduleUrl={tool.importUrl as AutomergeUrl}
+                      repo={props.repo}
+                    />
+                  </Show>
                 </article>
               </Suspense>
             );

--- a/tools/sideboard/src/module-settings/view-source.tsx
+++ b/tools/sideboard/src/module-settings/view-source.tsx
@@ -1,0 +1,201 @@
+import { createSignal, createResource, Show, For } from "solid-js";
+import type { AutomergeUrl, Repo } from "@automerge/automerge-repo";
+import type { FolderDoc } from "@patchwork/filesystem";
+
+interface ViewSourceProps {
+  moduleUrl: AutomergeUrl;
+  repo: Repo;
+}
+
+interface FileContent {
+  name: string;
+  path: string[];
+  content: string;
+  mimeType: string;
+}
+
+async function fetchFolderFiles(
+  url: AutomergeUrl,
+  repo: Repo,
+  path: string[] = []
+): Promise<FileContent[]> {
+  const handle = await repo.find(url);
+  await handle.whenReady();
+  const doc = handle.doc();
+
+  if (!doc) return [];
+
+  const files: FileContent[] = [];
+
+  // Check if this is a folder document
+  if (isFolderDoc(doc)) {
+    const folderDoc = doc as FolderDoc;
+
+    for (const docLink of folderDoc.docs) {
+      const childHandle = await repo.find(docLink.url);
+      await childHandle.whenReady();
+      const childDoc = childHandle.doc();
+
+      if (!childDoc) continue;
+
+      // If it's a folder, recurse
+      if (isFolderDoc(childDoc)) {
+        const subFiles = await fetchFolderFiles(docLink.url, repo, [
+          ...path,
+          docLink.name,
+        ]);
+        files.push(...subFiles);
+      } else {
+        // It's a file
+        const fileDoc = childDoc as any;
+        if (fileDoc.content) {
+          files.push({
+            name: docLink.name,
+            path: [...path, docLink.name],
+            content:
+              typeof fileDoc.content === "string"
+                ? fileDoc.content
+                : fileDoc.content.value ||
+                  JSON.stringify(fileDoc.content, null, 2),
+            mimeType: fileDoc.mimeType || "text/plain",
+          });
+        }
+      }
+    }
+  }
+
+  return files;
+}
+
+function isFolderDoc(doc: any): doc is FolderDoc {
+  return (
+    doc && typeof doc === "object" && "docs" in doc && Array.isArray(doc.docs)
+  );
+}
+
+function getLanguageFromMimeType(mimeType: string, filename: string): string {
+  if (mimeType.includes("javascript")) return "javascript";
+  if (mimeType.includes("typescript")) return "typescript";
+  if (mimeType.includes("json")) return "json";
+  if (mimeType.includes("css")) return "css";
+  if (mimeType.includes("html")) return "html";
+
+  // Fallback to file extension
+  const ext = filename.split(".").pop()?.toLowerCase();
+  if (ext === "ts" || ext === "tsx") return "typescript";
+  if (ext === "js" || ext === "jsx") return "javascript";
+  if (ext === "json") return "json";
+  if (ext === "css") return "css";
+  if (ext === "html") return "html";
+  if (ext === "md") return "markdown";
+
+  return "text";
+}
+
+export function ViewSource(props: ViewSourceProps) {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [selectedFile, setSelectedFile] = createSignal<FileContent | null>(
+    null
+  );
+
+  const [files] = createResource(
+    () => ({ url: props.moduleUrl, repo: props.repo, open: isOpen() }),
+    async ({ url, repo, open }) => {
+      if (!open) return [];
+      return fetchFolderFiles(url, repo);
+    }
+  );
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setSelectedFile(null);
+  };
+
+  return (
+    <>
+      <button class="view-source__button" onClick={handleOpen}>
+        View Source
+      </button>
+
+      <Show when={isOpen()}>
+        <div class="view-source__modal" onClick={handleClose}>
+          <div
+            class="view-source__modal-content"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div class="view-source__modal-header">
+              <h2>Module Source Files</h2>
+              <button class="view-source__close" onClick={handleClose}>
+                ✕
+              </button>
+            </div>
+
+            <Show when={files.loading}>
+              <p class="view-source__loading">Loading files...</p>
+            </Show>
+
+            <Show when={files.error}>
+              <p class="view-source__error">
+                Error loading files: {files.error?.message}
+              </p>
+            </Show>
+
+            <Show when={files() && files()!.length > 0}>
+              <div class="view-source__layout">
+                <div class="view-source__file-list">
+                  <h4>Files</h4>
+                  <For each={files()}>
+                    {(file) => (
+                      <button
+                        class="view-source__file-item"
+                        classList={{
+                          "view-source__file-item--selected":
+                            selectedFile()?.path.join("/") ===
+                            file.path.join("/"),
+                        }}
+                        onClick={() => setSelectedFile(file)}
+                      >
+                        {file.path.join("/")}
+                      </button>
+                    )}
+                  </For>
+                </div>
+
+                <Show when={selectedFile()}>
+                  <div class="view-source__file-preview">
+                    <h4>{selectedFile()!.name}</h4>
+                    <div class="view-source__file-meta">
+                      <code>{selectedFile()!.path.join("/")}</code>
+                      <span> • {selectedFile()!.mimeType}</span>
+                    </div>
+                    <pre class="view-source__code">
+                      <code
+                        class={`language-${getLanguageFromMimeType(selectedFile()!.mimeType, selectedFile()!.name)}`}
+                      >
+                        {selectedFile()!.content}
+                      </code>
+                    </pre>
+                  </div>
+                </Show>
+
+                <Show when={!selectedFile()}>
+                  <div class="view-source__empty-preview">
+                    <p>Select a file to view its contents</p>
+                  </div>
+                </Show>
+              </div>
+            </Show>
+
+            <Show when={files() && files()!.length === 0 && !files.loading}>
+              <p class="view-source__empty">No files found in this module.</p>
+            </Show>
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+}


### PR DESCRIPTION
Just threw it into module settings for now. 
- only works for tools loaded via pushwork / automerge URLs
- thrown into module settings view because we don't have a way to get to non-document tools in the UI

In future, it should be its own tool that:
- acts on docs which are 'file' or 'folder'
- supports editing via CodeMirror
- can open tools which are exposed in your account as folders, or via an automerge URL