### PR TITLE
add unlisted tools as a concept

### DIFF
--- a/core/element/src/patchwork-view.ts
+++ b/core/element/src/patchwork-view.ts
@@ -184,6 +184,9 @@ export function registerPatchworkViewElement(
           async (addedTool) => {
             const toolId = addedTool.id;
             const isChosenTool = toolId == this.toolId;
+            if (this.#handle) {
+              this.#fallbackId = getFallbackTool(this.#handle.doc())?.id;
+            }
             const isFallbackTool = toolId == this.#fallbackId;
 
             if (isChosenTool || isFallbackTool) {

--- a/core/plugins/src/registry/types.ts
+++ b/core/plugins/src/registry/types.ts
@@ -27,6 +27,7 @@ export interface PluginDescription {
   name: string;
   icon?: string; // an icon name from the icon font
   importUrl?: string;
+  unlisted?: boolean;
 }
 
 /**

--- a/core/plugins/src/registry/types.ts
+++ b/core/plugins/src/registry/types.ts
@@ -27,7 +27,6 @@ export interface PluginDescription {
   name: string;
   icon?: string; // an icon name from the icon font
   importUrl?: string;
-  unlisted?: boolean;
 }
 
 /**

--- a/core/plugins/src/tools.ts
+++ b/core/plugins/src/tools.ts
@@ -60,7 +60,7 @@ export function getFallbackTool(doc: HasPatchworkMetadata) {
     plugins,
     "supportedDataTypes",
     type
-  )?.[0];
+  )?.filter((tool) => !tool.unlisted)?.[0];
 }
 
 const sortPlugins = <

--- a/core/plugins/src/tools.ts
+++ b/core/plugins/src/tools.ts
@@ -28,6 +28,7 @@ export type ToolDescription = PluginDescription & {
   supportedDataTypes: "*" | string[];
   name: string;
   icon?: string;
+  unlisted?: boolean;
 };
 
 export type Tool = LoadedPlugin<ToolDescription, ToolImplementation>;

--- a/sites/tiny-patchwork/src/tools/back-link-button/index.ts
+++ b/sites/tiny-patchwork/src/tools/back-link-button/index.ts
@@ -12,5 +12,6 @@ export const plugins: Plugin<any>[] = [
       const { BackLinkButton } = await import("./BackLinkButton");
       return toolify(BackLinkButton);
     },
+    unlisted: true,
   },
 ];

--- a/tools/sideboard/src/sideboard/plugins.ts
+++ b/tools/sideboard/src/sideboard/plugins.ts
@@ -2,23 +2,21 @@ import type { MaybeAccessor } from "@automerge/automerge-repo-solid-primitives/d
 import {
   type ToolDescription,
   type DataTypeDescription,
-  type Tool,
-  type DataType,
   getSupportedToolsForType,
   getRegistry,
+  type Plugin,
 } from "@patchwork/plugins";
 import { createEffect, on, onCleanup } from "solid-js";
 import { createStore, reconcile } from "solid-js/store";
 
-// TODO: maybe these shouold go alongside the @patchwork/react package?
-
+// TODO: maybe these should go alongside the @patchwork/react package?
 const toolRegistry = getRegistry<ToolDescription>("patchwork:tool");
 const datatypeRegistry = getRegistry<DataTypeDescription>("patchwork:datatype");
 
 (window as any).toolRegistry = toolRegistry;
 (window as any).datatypeRegistry = datatypeRegistry;
 
-export function useTools(): Tool[] {
+export function useTools(): Plugin<ToolDescription>[] {
   const [plugins, setPlugins] = createStore(toolRegistry.all());
   const dispose = toolRegistry.on("changed", () =>
     setPlugins(reconcile(toolRegistry.all()))
@@ -27,12 +25,12 @@ export function useTools(): Tool[] {
   return plugins;
 }
 
-export function useDatatypes(filter: (item: DataType) => boolean): DataType[] {
-  const [plugins, setPlugins] = createStore(
-    datatypeRegistry.all().filter(filter)
-  );
+export function useDatatypes(
+  filter: (item: DataTypeDescription) => boolean
+): Plugin<DataTypeDescription>[] {
+  const [plugins, setPlugins] = createStore(datatypeRegistry.filter(filter));
   const dispose = datatypeRegistry.on("changed", () =>
-    setPlugins(reconcile(datatypeRegistry.all().filter(filter)))
+    setPlugins(reconcile(datatypeRegistry.filter(filter)))
   );
   onCleanup(dispose);
   return plugins;
@@ -44,7 +42,7 @@ function access(thing: MaybeAccessor<string>) {
 
 export function useSupportedToolsForType(type: MaybeAccessor<string>) {
   const [plugins, setPlugins] = createStore(
-    getSupportedToolsForType(access(type))
+    getSupportedToolsForType(access(type)).filter((tool) => !tool.unlisted)
   );
 
   createEffect(
@@ -52,7 +50,11 @@ export function useSupportedToolsForType(type: MaybeAccessor<string>) {
       () => access(type),
       (type) => {
         const dispose = toolRegistry.on("changed", () =>
-          setPlugins(reconcile(getSupportedToolsForType(type)))
+          setPlugins(
+            reconcile(
+              getSupportedToolsForType(type).filter((tool) => !tool.unlisted)
+            )
+          )
         );
         onCleanup(dispose);
       }

--- a/tools/sync-indicator/src/tool.tsx
+++ b/tools/sync-indicator/src/tool.tsx
@@ -10,6 +10,7 @@ export const plugins = [
     name: "Sync Indicator",
     icon: "Wifi",
     supportedDataTypes: "*" as const,
+    unlisted: true,
     async load(): Promise<ToolImplementation> {
       return (handle, element) => {
         element.style.width = "fit-content";


### PR DESCRIPTION
introduces the datatype's `unlisted` property to the tool description too

- adds unlisted tools as a concept
- hides unlisted tools from the open with menu
- stops patchwork-view falling back to unlisted tools