### PR TITLE
use vite build --watch for dev script

### DIFF
--- a/sites/gaios/package.json
+++ b/sites/gaios/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/gaios/package.json
+++ b/sites/gaios/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/gaios/package.json
+++ b/sites/gaios/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/hive/package.json
+++ b/sites/hive/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/hive/package.json
+++ b/sites/hive/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/hive/package.json
+++ b/sites/hive/package.json
@@ -8,7 +8,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -18,7 +18,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "sync": "vite build && pushwork sync"

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -18,7 +18,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
     "sync": "vite build && pushwork sync"

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -18,7 +18,7 @@
     "vite-plugin-wasm": "^3.4.1"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "preview": "vite preview",
     "sync": "vite build && pushwork sync"

--- a/tools/back-link-button/package.json
+++ b/tools/back-link-button/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/comments-view/package.json
+++ b/tools/comments-view/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/context-sidebar/package.json
+++ b/tools/context-sidebar/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/context-view/package.json
+++ b/tools/context-view/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/doc-title/package.json
+++ b/tools/doc-title/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/frame-configurator/package.json
+++ b/tools/frame-configurator/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/highlight-changes-checkbox/package.json
+++ b/tools/highlight-changes-checkbox/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/history-view/package.json
+++ b/tools/history-view/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/patchwork-frame/package.json
+++ b/tools/patchwork-frame/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/spacer/package.json
+++ b/tools/spacer/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },

--- a/tools/todo/package.json
+++ b/tools/todo/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "build": "vite build",
     "sync": "vite build && pushwork sync"
   },


### PR DESCRIPTION
so that we don't start a whole bunch of vite servers when running `pnpm dev` in the root, and tools are built into their dist folders
