### PR TITLE
Add a trashy setTitle to markdown files

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,6 +739,9 @@ importers:
 
   tools/codemirror-markdown:
     dependencies:
+      '@automerge/automerge':
+        specifier: 3.2.0
+        version: 3.2.0
       '@codemirror/autocomplete':
         specifier: ^6.19.0
         version: 6.19.0

--- a/tools/codemirror-markdown/package.json
+++ b/tools/codemirror-markdown/package.json
@@ -24,6 +24,7 @@
     "pushwatch": "pnpm dev pushwork"
   },
   "dependencies": {
+    "@automerge/automerge": "catalog:",
     "@codemirror/autocomplete": "^6.19.0",
     "@codemirror/commands": "^6.9.0",
     "@codemirror/lang-markdown": "^6.4.0",

--- a/tools/codemirror-markdown/src/datatype.ts
+++ b/tools/codemirror-markdown/src/datatype.ts
@@ -1,16 +1,19 @@
 import { type DataTypeImplementation } from "@patchwork/plugins";
+import { updateText } from "@automerge/automerge";
 
 export type MarkdownDoc = {
   content: string;
 };
 
+const frontmatterRegex = /---\n([\s\S]+?)\n---/;
+
 export const MarkdownDataType: DataTypeImplementation<MarkdownDoc> = {
-  init: (doc: MarkdownDoc) => {
+  init(doc: MarkdownDoc) {
     doc.content = "# Untitled";
   },
   getTitle(doc: MarkdownDoc) {
     const content = doc.content;
-    const frontmatterRegex = /---\n([\s\S]+?)\n---/;
+
     const frontmatterMatch = content.match(frontmatterRegex);
     const frontmatter = frontmatterMatch ? frontmatterMatch[1] : "";
 
@@ -31,5 +34,25 @@ export const MarkdownDataType: DataTypeImplementation<MarkdownDoc> = {
     }
 
     return `${title}${subtitle && `: ${subtitle}`}`;
+  },
+  setTitle(doc: MarkdownDoc, title: string) {
+    const hasTitle = doc.content.match(/^#\s/gm);
+    const hasFrontmatter = frontmatterRegex.exec(doc.content);
+
+    if (hasTitle) {
+      updateText(
+        doc,
+        ["content"],
+        doc.content.replace(/^#\s+(.*)/gm, () => `# ${title}`)
+      );
+    } else {
+      // todo
+      if (hasFrontmatter) return;
+      updateText(
+        doc,
+        ["content"],
+        (doc.content = `# ${title}\n` + doc.content)
+      );
+    }
   },
 };

--- a/tools/codemirror-markdown/src/main.tsx
+++ b/tools/codemirror-markdown/src/main.tsx
@@ -21,4 +21,15 @@ export const plugins = [
       return MarkdownDataType;
     },
   },
+  {
+    type: "patchwork:datatype",
+    id: "essay",
+    name: "Markdown",
+    icon: "FileText",
+    unlisted: true,
+    async load() {
+      const { MarkdownDataType } = await import("./datatype.js");
+      return MarkdownDataType;
+    },
+  },
 ];


### PR DESCRIPTION
also reëxports markdown as "essay" unlisted so that the getTitle and setTitle work on them too.