### PR TITLE
feat: enable codemirror-embed by default

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,7 +306,7 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
 
-  packages/solidjs:
+  packages/solid:
     dependencies:
       '@automerge/automerge-repo-solid-primitives':
         specifier: 'catalog:'
@@ -442,6 +442,9 @@ importers:
       '@grjte/codemirror-base':
         specifier: workspace:^
         version: link:../../tools/codemirror-base
+      '@grjte/codemirror-embed':
+        specifier: workspace:^
+        version: link:../../tools/codemirror-embed
       '@grjte/codemirror-markdown':
         specifier: workspace:^
         version: link:../../tools/codemirror-markdown
@@ -1792,7 +1795,7 @@ importers:
         version: link:../../core/filesystem
       '@patchwork/solid':
         specifier: workspace:^
-        version: link:../../packages/solidjs
+        version: link:../../packages/solid
       solid-js:
         specifier: ^1.9.9
         version: 1.9.9

--- a/sites/tiny-patchwork/package.json
+++ b/sites/tiny-patchwork/package.json
@@ -34,6 +34,7 @@
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.4",
     "@grjte/codemirror-base": "workspace:^",
+    "@grjte/codemirror-embed": "workspace:^",
     "@grjte/codemirror-markdown": "workspace:^",
     "@grjte/codemirror-md-links": "workspace:^",
     "@orion/commands": "workspace:^",

--- a/sites/tiny-patchwork/src/tools/index.ts
+++ b/sites/tiny-patchwork/src/tools/index.ts
@@ -35,6 +35,8 @@ import { plugins as orionMarkwhen } from "@orion/markwhen";
 // @ts-expect-error no types
 import { plugins as codemirrorBasePlugins } from "@grjte/codemirror-base";
 // @ts-expect-error no types
+import { plugins as codemirrorEmbedPlugins } from "@grjte/codemirror-embed";
+// @ts-expect-error no types
 import { plugins as codemirrorMarkdownPlugins } from "@grjte/codemirror-markdown";
 // @ts-expect-error no types
 import { plugins as markdownLinksPlugins } from "@grjte/codemirror-md-links";
@@ -64,6 +66,7 @@ export const plugins: Plugin<any>[] = [
   ...codemirrorBasePlugins,
   ...codemirrorMarkdownPlugins,
   ...markdownLinksPlugins,
+  ...codemirrorEmbedPlugins,
   {
     id: "folder",
     type: "patchwork:datatype",


### PR DESCRIPTION
temporarily install and hard-code codemirror-embed in plugins list within tiny-patchwork alongside other tools