### PR TITLE
Allow multiple module settings docs in module watcher

### DIFF
--- a/core/filesystem/src/module-watcher.ts
+++ b/core/filesystem/src/module-watcher.ts
@@ -22,24 +22,40 @@ export type ModuleSettingsDoc = {
  * It also watches the modules themselves for changes and reloads them when they change.
  */
 export class ModuleWatcher {
+  repo: Repo;
+  urls: AutomergeUrl[];
+  handles: DocHandle<ModuleSettingsDoc>[] | undefined;
+  doneLoading: Promise<void>;
+
+  onLoad: (name: string, mod: any) => void;
+
   constructor(
-    private moduleSettingsUrl: AutomergeUrl,
-    private baselineModules: string[],
-    private repo: Repo,
-    private callback: (name: string, mod: any) => void
+    repo: Repo,
+    urls: AutomergeUrl | AutomergeUrl[],
+    callback: (name: string, mod: any) => void
   ) {
+    this.repo = repo;
+    this.urls = Array.isArray(urls) ? urls : [urls];
+    this.onLoad = callback;
     this.doneLoading = this.init();
   }
 
-  moduleSettingsHandle: DocHandle<ModuleSettingsDoc> | undefined;
-  doneLoading: Promise<void>;
+  onChange = () => this.load().catch(console.error);
 
   private async init() {
-    this.moduleSettingsHandle = await this.repo.find(this.moduleSettingsUrl);
-    await this.loadModules(this.baselineModules);
-    this.moduleSettingsHandle.on("change", () =>
-      this.load().catch(console.error)
-    );
+    this.handles = (
+      await Promise.allSettled(
+        this.urls.map(async (url) => this.repo.find<ModuleSettingsDoc>(url))
+      )
+    )
+      .filter((result) => {
+        return result.status == "fulfilled";
+      })
+      .map((result) => result.value);
+
+    for (const handle of this.handles) {
+      handle.addListener("change", this.onChange);
+    }
     await this.load();
   }
 
@@ -47,7 +63,13 @@ export class ModuleWatcher {
     await Promise.all(
       modules.map(async (importName) => {
         this.setDocWatcher(importName);
-        await this.report(importName).catch(console.warn);
+        await this.report(importName).catch((error) => {
+          console.log(
+            new Error(`Failed to load module ${importName}: ${error}`, {
+              cause: error,
+            })
+          );
+        });
       })
     );
   }
@@ -78,7 +100,7 @@ export class ModuleWatcher {
 
   private async report(importName: string) {
     const mod = await this.importModuleSafe(importName);
-    mod && this.callback(importName, mod);
+    mod && this.onLoad(importName, mod);
   }
 
   // TODO: This is a bit janky and relies on a bunch of heuristics.
@@ -101,9 +123,11 @@ export class ModuleWatcher {
   }
 
   private async load() {
-    if (!this.moduleSettingsHandle) throw new Error("No moduleSettingsHandle");
-    const doc = this.moduleSettingsHandle.doc();
-    const { modules = [] } = doc;
-    await this.loadModules(modules);
+    if (!this.handles) throw new Error("No handles");
+    for (const handle of this.handles) {
+      const doc = handle.doc();
+      const { modules = [] } = doc;
+      await this.loadModules(modules);
+    }
   }
 }

--- a/sites/gaios/src/main.ts
+++ b/sites/gaios/src/main.ts
@@ -126,9 +126,8 @@ const accountDocHandle = await getOrCreateLayoutDocHandle(repo);
 window.accountDocHandle = accountDocHandle;
 
 const moduleWatcher = new ModuleWatcher(
-  accountDocHandle.doc().moduleSettingsUrl,
-  [],
   repo,
+  accountDocHandle.doc().moduleSettingsUrl,
   (name, mod) => {
     if (Array.isArray(mod.plugins)) {
       // TODO: maybe get rid of this check?

--- a/sites/hive/src/main.ts
+++ b/sites/hive/src/main.ts
@@ -59,9 +59,8 @@ bootstrap(async (href, request) =>
 );
 
 const moduleWatcher = new ModuleWatcher(
-  "automerge:3n51DZbA1FRwHAV8K2sW1g2aA3P2" as AutomergeUrl,
-  [],
   repo,
+  "automerge:3n51DZbA1FRwHAV8K2sW1g2aA3P2" as AutomergeUrl,
   (name, mod) => {
     Array.isArray(mod.plugins) && registerPlugins(mod.plugins, name);
   }

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -29,12 +29,14 @@ import {
   Repo,
   stringifyAutomergeUrl,
   WebSocketClientAdapter,
+  type AutomergeUrl,
   type UrlHeads,
 } from "@automerge/vanillajs";
 import { plugins } from "./tools";
 import * as Automerge from "@automerge/automerge";
 import * as AutomergeRepo from "@automerge/automerge-repo";
 
+// todo maybe we should have a window.patchwork namespace for this?
 declare global {
   interface Window {
     accountDocHandle: DocHandle<TinyPatchworkLayoutDoc>;
@@ -42,46 +44,48 @@ declare global {
     Automerge: typeof import("@automerge/automerge");
     AutomergeRepo: typeof import("@automerge/automerge-repo");
     repo: Repo;
-    getRepoChannel: () => MessagePort
+    getRepoChannel: () => MessagePort;
   }
 }
 
-const repo = new Repo({storage: new IndexedDBStorageAdapter()})
+const repo = new Repo({ storage: new IndexedDBStorageAdapter() });
 
 function createSharedWorker() {
-   return new SharedWorker(
-    new URL("./automerge-worker.ts", import.meta.url),
-    {
-      type: "module",
-      name: "automerge-repo-shared-worker",
-    }
-  )
+  return new SharedWorker(new URL("./automerge-worker.ts", import.meta.url), {
+    type: "module",
+    name: "automerge-repo-shared-worker",
+  });
 }
 
 function getRepoChannel() {
   try {
-    const worker = createSharedWorker()
-    return worker.port
+    const worker = createSharedWorker();
+    return worker.port;
   } catch (error) {
-    console.error(error)
-    console.error("Falling back to tab-only repo strategy")
-    const {port1, port2} = new MessageChannel()
-    repo.networkSubsystem.addNetworkAdapter(new MessageChannelNetworkAdapter(port1))
-    return port2
+    console.error(error);
+    console.error("Falling back to tab-only repo strategy");
+    const { port1, port2 } = new MessageChannel();
+    repo.networkSubsystem.addNetworkAdapter(
+      new MessageChannelNetworkAdapter(port1)
+    );
+    return port2;
   }
 }
 
-window.getRepoChannel = getRepoChannel
+window.getRepoChannel = getRepoChannel;
 
 try {
-  const sharedWorker = createSharedWorker()
-  repo.networkSubsystem.addNetworkAdapter(new MessageChannelNetworkAdapter(sharedWorker.port))
+  const sharedWorker = createSharedWorker();
+  repo.networkSubsystem.addNetworkAdapter(
+    new MessageChannelNetworkAdapter(sharedWorker.port)
+  );
 } catch (error) {
-  console.error(error)
-  console.error("Falling back to tab-only repo strategy")
-  repo.networkSubsystem.addNetworkAdapter(new WebSocketClientAdapter("wss://sync3.automerge.org"))
+  console.error(error);
+  console.error("Falling back to tab-only repo strategy");
+  repo.networkSubsystem.addNetworkAdapter(
+    new WebSocketClientAdapter("wss://sync3.automerge.org")
+  );
 }
-
 
 window.repo = repo;
 window.Automerge = Automerge;
@@ -125,10 +129,12 @@ const accountDocHandle = await getOrCreateLayoutDocHandle(repo);
 
 window.accountDocHandle = accountDocHandle;
 
-const moduleWatcher = new ModuleWatcher(
-  accountDocHandle.doc().moduleSettingsUrl,
-  [],
+const _moduleWatcher = new ModuleWatcher(
   repo,
+  [
+
+    accountDocHandle.doc().moduleSettingsUrl,
+  ],
   (name, mod) => {
     if (Array.isArray(mod.plugins)) {
       // TODO: maybe get rid of this check?
@@ -139,7 +145,7 @@ const moduleWatcher = new ModuleWatcher(
   }
 );
 
-registerPatchworkViewElement({ moduleWatcher, repo });
+registerPatchworkViewElement({ repo });
 
 const rootElement = document.getElementById("root")!;
 


### PR DESCRIPTION
This is part of #87, so that we can include site-level and org-level module settings urls.

