### PR TITLE
Indicate required version of node in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.2.4"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "volta": {
     "node": "24.11.1"
   },


### PR DESCRIPTION
I tried running this with the node version I happened to have selected (20) and got the following error:

```
...
tools/tiny-patchwork/commands dev: node:internal/modules/esm/get_format:189
tools/tiny-patchwork/commands dev:   throw new ERR_UNKNOWN_FILE_EXTENSION(ext, filepath);
tools/tiny-patchwork/commands dev:         ^
tools/tiny-patchwork/commands dev: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /home/maciek/code/aux/i-and-s/patchwork-next/tools/tiny-patchwork/commands/esbuild/watch.ts
...
```

Upgrading to 24 resolved this (I'm still hitting a different error,
but I don't think that's related to node version), and 22 seems to
avoid the original error as well.
