### PR TITLE
Enable keyhive in tiny patchwork

### DIFF
--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -59,8 +59,8 @@
   },
   "peerDependencies": {
     "@automerge/automerge": "catalog:",
-    "@automerge/automerge-repo": "*",
-    "@automerge/automerge-repo-keyhive": "*",
+    "@automerge/automerge-repo": "catalog:",
+    "@automerge/automerge-repo-keyhive": "catalog:",
     "@automerge/vanillajs": "catalog:"
   },
   "scripts": {

--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
-    "@automerge/automerge-repo-keyhive": "link:../../../automerge-repo-keyhive",
+    "@automerge/automerge-repo-keyhive": "catalog:",
     "esbuild": "^0.23.1",
     "rollup": "^4.53.3"
   },

--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
-    "@automerge/automerge-repo-keyhive": "catalog:",
+    "@automerge/automerge-repo-keyhive": "link:../../../automerge-repo-keyhive",
     "esbuild": "^0.23.1",
     "rollup": "^4.53.3"
   },
@@ -47,6 +47,7 @@
     "@automerge/automerge-repo-network-websocket": "catalog:",
     "@automerge/automerge-repo-storage-indexeddb": "catalog:",
     "@automerge/vanillajs": "catalog:",
+    "@keyhive/keyhive": "catalog:",
     "@inkandswitch/patchwork-elements": "workspace:^",
     "@inkandswitch/patchwork-filesystem": "workspace:^",
     "@inkandswitch/patchwork-plugins": "workspace:^",
@@ -58,8 +59,8 @@
   },
   "peerDependencies": {
     "@automerge/automerge": "catalog:",
-    "@automerge/automerge-repo": "catalog:",
-    "@automerge/automerge-repo-keyhive": "catalog:",
+    "@automerge/automerge-repo": "*",
+    "@automerge/automerge-repo-keyhive": "*",
     "@automerge/vanillajs": "catalog:"
   },
   "scripts": {

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -197,7 +197,7 @@ function getRepoHive() {
 
       (self as any).repo = repo;
       (self as any).hive = hive;
-      logger.info("repo constructed, waiting for network subsystem");
+      logger.info("repo constructed (E2EE enabled), waiting for network subsystem");
 
       // Don't block getRepoHive() on whenReady() — the network subsystem starts
       // with only the subduction adapter, and the MessageChannel adapter is

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -187,6 +187,7 @@ function getRepoHive() {
         peerId: hive.peerId,
         enableRemoteHeadsGossiping: true,
         idFactory: hive.idFactory,
+        subductionBlobInterceptor: hive.blobInterceptor,
         //network: [new WebSocketClientAdapter("wss://sync3.automerge.org")],
       });
 

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -12,6 +12,7 @@ import { initializeWasm, hasHeads } from "@automerge/automerge/slim";
 // eslint-disable-next-line
 // @ts-ignore — initSync is a wasm-bindgen runtime helper not in the .d.ts
 import { initSync as initSubductionSync } from "@automerge/automerge-subduction/slim";
+import { WebCryptoSigner } from "@automerge/automerge-subduction/slim";
 
 import {
   Repo,
@@ -33,6 +34,7 @@ import {
 } from "@automerge/automerge-repo-keyhive";
 
 declare const __SITE_NAME__: string;
+declare const __KEYHIVE__: boolean;
 
 // TEMPORARY: enable debug npm module in SW context (no localStorage available)
 
@@ -40,8 +42,7 @@ let cachename = "default";
 let debugging = false;
 const workerInstanceId = crypto.randomUUID();
 
-// const SUBDUCTION_ENDPOINTS = ["wss://subduction.sync.inkandswitch.com"];
-const SUBDUCTION_ENDPOINTS = ["ws://localhost:3030"];
+const SUBDUCTION_ENDPOINTS = ["wss://subduction.sync.inkandswitch.com"];
 const RESOLVE_TIMEOUT_MS = 30_000;
 
 // ── Persistent logger ───────────────────────────────────────────────────
@@ -107,8 +108,10 @@ self.addEventListener("activate", async () => {
 
 let repoHivePromise: Promise<{
   repo: Repo;
-  hive: AutomergeRepoKeyhiveRust;
+  hive?: AutomergeRepoKeyhiveRust;
 }> | null = null;
+
+const useKeyhive = typeof __KEYHIVE__ !== "undefined" && __KEYHIVE__;
 
 function getRepoHive() {
   if (!repoHivePromise) {
@@ -124,6 +127,31 @@ function getRepoHive() {
       initSubductionSync(new Uint8Array(sdnWasmBuf));
       await initializeWasm(new Uint8Array(amWasmBuf));
       logger.info("wasm initialized");
+
+      if (!useKeyhive) {
+        const signer = await WebCryptoSigner.setup();
+
+        const repo = new Repo({
+          storage: new IndexedDBStorageAdapter(),
+          signer,
+          peerId: ("service-worker-" +
+            Math.random().toString(36).slice(2)) as import("@automerge/automerge-repo/slim").PeerId,
+          async sharePolicy(peerId) {
+            return peerId.includes("storage-server");
+          },
+          enableRemoteHeadsGossiping: true,
+          subductionWebsocketEndpoints: SUBDUCTION_ENDPOINTS,
+        });
+
+        (self as any).repo = repo;
+        logger.info("repo constructed (no keyhive), waiting for network subsystem");
+
+        repo.networkSubsystem.whenReady().then(() => {
+          logger.info("repo network subsystem ready");
+        });
+
+        return { repo };
+      }
 
       initKeyhiveWasm();
       const keyhiveStorage = new IndexedDBStorageAdapter(
@@ -197,6 +225,12 @@ function getRepoHive() {
 async function connectPort(port: MessagePort) {
   const { hive, repo } = await getRepoHive();
   const networkAdapter = new MessageChannelNetworkAdapter(port, { useWeakRef: true });
+
+  if (!hive) {
+    repo.networkSubsystem.addNetworkAdapter(networkAdapter);
+    return;
+  }
+
   const onlyShareWithHardcodedServerPeerId = false;
   const periodicallyRequestKeyhiveSync = false;
   const keyhiveNetworkAdapter = hive.createKeyhiveNetworkAdapter(networkAdapter, onlyShareWithHardcodedServerPeerId, periodicallyRequestKeyhiveSync, 2000);

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -187,7 +187,7 @@ function getRepoHive() {
         peerId: hive.peerId,
         enableRemoteHeadsGossiping: true,
         idFactory: hive.idFactory,
-        subductionBlobInterceptor: hive.blobInterceptor,
+        // subductionBlobInterceptor: hive.blobInterceptor,
         //network: [new WebSocketClientAdapter("wss://sync3.automerge.org")],
       });
 
@@ -197,7 +197,7 @@ function getRepoHive() {
 
       (self as any).repo = repo;
       (self as any).hive = hive;
-      logger.info("repo constructed (E2EE enabled), waiting for network subsystem");
+      logger.info("repo constructed, waiting for network subsystem");
 
       // Don't block getRepoHive() on whenReady() — the network subsystem starts
       // with only the subduction adapter, and the MessageChannel adapter is

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -42,7 +42,7 @@ let cachename = "default";
 let debugging = false;
 const workerInstanceId = crypto.randomUUID();
 
-const SUBDUCTION_ENDPOINTS = ["ws://localhost:3030"];
+const SUBDUCTION_ENDPOINTS = ["wss://keyhive.sync.automerge.org"];
 const RESOLVE_TIMEOUT_MS = 30_000;
 
 // ── Persistent logger ───────────────────────────────────────────────────

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -43,6 +43,7 @@ let debugging = false;
 const workerInstanceId = crypto.randomUUID();
 
 const SUBDUCTION_ENDPOINTS = ["wss://keyhive.sync.automerge.org"];
+
 const RESOLVE_TIMEOUT_MS = 30_000;
 
 // ── Persistent logger ───────────────────────────────────────────────────

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -12,14 +12,13 @@ import { initializeWasm, hasHeads } from "@automerge/automerge/slim";
 // eslint-disable-next-line
 // @ts-ignore — initSync is a wasm-bindgen runtime helper not in the .d.ts
 import { initSync as initSubductionSync } from "@automerge/automerge-subduction/slim";
-import { WebCryptoSigner } from "@automerge/automerge-subduction/slim";
 
 import {
   Repo,
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
-  type PeerId,
+  type AutomergeUrl,
 } from "@automerge/automerge-repo/slim";
 import { resolvePath } from "@inkandswitch/patchwork-filesystem";
 
@@ -27,13 +26,22 @@ import { resolvePath } from "@inkandswitch/patchwork-filesystem";
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel";
 import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
+import {
+  initializeAutomergeRepoKeyhiveRust,
+  initKeyhiveWasm,
+  type AutomergeRepoKeyhiveRust,
+} from "@automerge/automerge-repo-keyhive";
+
+declare const __SITE_NAME__: string;
 
 // TEMPORARY: enable debug npm module in SW context (no localStorage available)
+
 let cachename = "default";
 let debugging = false;
 const workerInstanceId = crypto.randomUUID();
 
-const SUBDUCTION_ENDPOINTS = ["wss://subduction.sync.inkandswitch.com"];
+// const SUBDUCTION_ENDPOINTS = ["wss://subduction.sync.inkandswitch.com"];
+const SUBDUCTION_ENDPOINTS = ["ws://localhost:3030"];
 const RESOLVE_TIMEOUT_MS = 30_000;
 
 // ── Persistent logger ───────────────────────────────────────────────────
@@ -63,6 +71,8 @@ const slog = SwLogger.open().then((logger) => {
   logger.info("sw-logger initialized");
   return logger;
 });
+
+const siteName = typeof __SITE_NAME__ !== "undefined" ? __SITE_NAME__ : "tiny-patchwork";
 
 const cacheableStatuses = [200, 203, 204, 206];
 
@@ -95,11 +105,14 @@ self.addEventListener("activate", async () => {
   clients.claim();
 });
 
-let repoPromise: Promise<Repo> | null = null;
+let repoHivePromise: Promise<{
+  repo: Repo;
+  hive: AutomergeRepoKeyhiveRust;
+}> | null = null;
 
-function getRepo() {
-  if (!repoPromise) {
-    const p: Promise<Repo> = (async () => {
+function getRepoHive() {
+  if (!repoHivePromise) {
+    repoHivePromise = (async () => {
       const logger = await slog;
       logger.info("getRepo: starting");
 
@@ -112,51 +125,99 @@ function getRepo() {
       await initializeWasm(new Uint8Array(amWasmBuf));
       logger.info("wasm initialized");
 
-      const signer = await WebCryptoSigner.setup();
+      initKeyhiveWasm();
+      const keyhiveStorage = new IndexedDBStorageAdapter(
+        `${siteName}-keyhive`
+      );
+
+      // Keyhive bootstrap needs to run before Repo creation but
+      // the adapter needs the subduction instance from the Repo.
+      // A deferred promise breaks the cycle.
+      let resolveRepoSubduction!: (s: any) => void;
+      const repoSubductionPromise = new Promise((resolve) => {
+        resolveRepoSubduction = resolve;
+      });
+
+      // We use the Rust variant of Keyhive initialization to talk
+      // to the Rust keyhive-enabled subduction sync server.
+      const hive = await initializeAutomergeRepoKeyhiveRust({
+        storage: keyhiveStorage,
+        peerIdSuffix:
+          `${siteName}-worker` + Math.random().toString(36).slice(2),
+        subduction: repoSubductionPromise as any,
+        automaticArchiveIngestion: true,
+        cachingMode: "periodic",
+      });
+
+      const signer = await hive.constructSubductionSigner();
 
       const repo = new Repo({
         storage: new IndexedDBStorageAdapter(),
         signer,
-        peerId: ("service-worker-" +
-          (Math.random() * 10000).toString(36).slice(2)) as PeerId,
-        async sharePolicy(peerId) {
-          return peerId.includes("storage-server");
-        },
-        enableRemoteHeadsGossiping: true,
         subductionWebsocketEndpoints: SUBDUCTION_ENDPOINTS,
+        peerId: hive.peerId,
+        enableRemoteHeadsGossiping: true,
+        idFactory: hive.idFactory,
         //network: [new WebSocketClientAdapter("wss://sync3.automerge.org")],
       });
 
+      repo.subduction.then(resolveRepoSubduction);
+
+      hive.linkRepo(repo);
+
       (self as any).repo = repo;
+      (self as any).hive = hive;
       logger.info("repo constructed, waiting for network subsystem");
 
-      // Don't block getRepo() on whenReady() — the network subsystem starts
+      // Don't block getRepoHive() on whenReady() — the network subsystem starts
       // with only the subduction adapter, and the MessageChannel adapter is
-      // added later via connectPort (which awaits getRepo). Blocking here
+      // added later via connectPort (which awaits getRepoHive). Blocking here
       // would deadlock that path and starve the fetch handler.
       repo.networkSubsystem.whenReady().then(() => {
         logger.info("repo network subsystem ready");
       });
 
-      return repo;
+      hive.networkAdapter.whenReady().then(() => {
+        (hive.networkAdapter as any).syncKeyhive();
+      });
+
+      return { hive, repo };
     })();
     // If construction fails (e.g. wasm fetch errors out because the SW was
     // terminated mid-flight), don't permanently cache the rejection — clear
     // the slot so the next caller can retry from scratch.
-    p.catch(() => {
-      if (repoPromise === p) repoPromise = null;
+    repoHivePromise.catch(() => {
+      repoHivePromise = null;
     });
-    repoPromise = p;
   }
-  return repoPromise;
+  return repoHivePromise;
 }
 
 // Connect client MessagePorts to the repo for sync
 async function connectPort(port: MessagePort) {
-  const repo = await getRepo();
-  repo.networkSubsystem.addNetworkAdapter(
-    new MessageChannelNetworkAdapter(port, { useWeakRef: true })
-  );
+  const { hive, repo } = await getRepoHive();
+  const networkAdapter = new MessageChannelNetworkAdapter(port, { useWeakRef: true });
+  const onlyShareWithHardcodedServerPeerId = false;
+  const periodicallyRequestKeyhiveSync = false;
+  const keyhiveNetworkAdapter = hive.createKeyhiveNetworkAdapter(networkAdapter, onlyShareWithHardcodedServerPeerId, periodicallyRequestKeyhiveSync, 2000);
+
+  keyhiveNetworkAdapter.on("message", async (msg: any) => {
+    if ((msg.type === "sync" || msg.type === "request") && msg.documentId) {
+      const handle = repo.handles[msg.documentId];
+      if (!handle || handle.state === "unavailable") {
+        const url = `automerge:${msg.documentId}` as AutomergeUrl;
+        repo.findWithProgress(url);
+        repo.shareConfigChanged();
+      }
+    }
+  });
+
+  (keyhiveNetworkAdapter as any).on("ingest-remote", () => {
+    (hive.networkAdapter as any).syncKeyhive?.();
+    repo.shareConfigChanged();
+  });
+
+  repo.networkSubsystem.addNetworkAdapter(keyhiveNetworkAdapter);
 }
 
 self.addEventListener("message", async (event) => {
@@ -219,7 +280,7 @@ self.addEventListener("message", async (event) => {
 // ── Automerge URL resolution ───────────────────────────────────────────
 
 async function resolveAutomergeUrl(automergeURL: URL): Promise<Response> {
-  const repo = await getRepo();
+  const { repo } = await getRepoHive();
   const href = automergeURL.href;
   const [maybeAutomergeUrl, ...path] = href.split("/");
 
@@ -362,8 +423,13 @@ self.addEventListener("fetch", (fetchEvent: FetchEvent) => {
           error instanceof Error
             ? `${error.message}\n\n${error.stack}`
             : String(error);
-        console.error(
-          `service worker error resolving ${request.url}${specialURL ? ` (for: ${specialURL})` : ""}.\n${message}`
+        const logger = await slog;
+        logger.error(
+          `service worker error resolving ${request.url}${specialURL ? ` (for: ${specialURL})` : ""}`,
+          {
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          }
         );
         if (match) return match;
 

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -42,7 +42,7 @@ let cachename = "default";
 let debugging = false;
 const workerInstanceId = crypto.randomUUID();
 
-const SUBDUCTION_ENDPOINTS = ["wss://subduction.sync.inkandswitch.com"];
+const SUBDUCTION_ENDPOINTS = ["ws://localhost:3030"];
 const RESOLVE_TIMEOUT_MS = 30_000;
 
 // ── Persistent logger ───────────────────────────────────────────────────

--- a/core/bootloader/src/site.ts
+++ b/core/bootloader/src/site.ts
@@ -28,9 +28,18 @@ import {
 } from "@automerge/vanillajs/slim";
 import * as Automerge from "@automerge/automerge/slim";
 import * as AutomergeRepo from "@automerge/automerge-repo/slim";
+import {
+  initKeyhiveWasm,
+  initializeAutomergeRepoKeyhive,
+  type AutomergeRepoKeyhive,
+} from "@automerge/automerge-repo-keyhive";
 // eslint-disable-next-line
 // @ts-ignore — initSync is a wasm-bindgen runtime helper not in the .d.ts
 import { initSync as initSubductionSync } from "@automerge/automerge-subduction/slim";
+
+declare const __SITE_NAME__: string;
+const siteName =
+  typeof __SITE_NAME__ !== "undefined" ? __SITE_NAME__ : "tiny-patchwork";
 
 import { ModuleWatcher } from "@inkandswitch/patchwork-filesystem";
 import {
@@ -60,6 +69,8 @@ declare global {
     Automerge: typeof import("@automerge/automerge");
     AutomergeRepo: typeof import("@automerge/automerge-repo");
     repo: Repo;
+    hive?: AutomergeRepoKeyhive;
+    getRepoChannel: () => MessagePort;
     patchwork: {
       repo: Repo;
       packages: ModuleWatcher;
@@ -116,6 +127,13 @@ export interface SiteConfig {
    * Ink & Switch's production Subduction storage.
    */
   remoteStorageIds?: StorageId[];
+
+  /**
+   * When true, initialize keyhive for access control.
+   * The Repo will use keyhive's network adapter, peerId, and idFactory
+   * instead of a sharePolicy.
+   */
+  keyhive?: boolean;
 }
 
 export interface BootResult {
@@ -154,35 +172,73 @@ export async function bootPatchworkSite(
   await initializeWasm(automergeWasm);
   initSubductionSync(subductionWasm);
 
-  const repo = new Repo({
-    storage: new IndexedDBStorageAdapter(),
-    async sharePolicy(peerId) {
-      return peerId.includes("service-worker");
-    },
-    enableRemoteHeadsGossiping: true,
-    peerId:
-      `${config.titleSuffix}-tab-${crypto.randomUUID()}` as AutomergeRepo.PeerId,
-  });
+  const sw = await setupServiceWorker();
+  if (!sw) throw new Error("Failed to set up service worker");
 
+  let hive: AutomergeRepoKeyhive | undefined;
+  if (config.keyhive) {
+    initKeyhiveWasm();
+
+    // Get the initial SW port via subscribeToRepoChannel, then pass it
+    // to keyhive init which wraps it in its own network adapter.
+    let resolvePort!: (port: MessagePort) => void;
+    const portPromise = new Promise<MessagePort>((r) => { resolvePort = r; });
+    sw.subscribeToRepoChannel((port) => { resolvePort(port); });
+    const swPort = await portPromise;
+
+    hive = await initializeAutomergeRepoKeyhive({
+      storage: new IndexedDBStorageAdapter(
+        `${siteName}-keyhive`
+      ),
+      peerIdSuffix:
+        siteName +
+        Math.random().toString(36).slice(2),
+      networkAdapter: new MessageChannelNetworkAdapter(swPort),
+      automaticArchiveIngestion: true,
+      cachingMode: "periodic",
+      onlyShareWithHardcodedServerPeerId: false,
+    });
+  }
+
+  const repo = hive
+    ? new Repo({
+        storage: new IndexedDBStorageAdapter(),
+        enableRemoteHeadsGossiping: true,
+        network: [hive.networkAdapter],
+        peerId: hive.peerId,
+        idFactory: hive.idFactory,
+      })
+    : new Repo({
+        storage: new IndexedDBStorageAdapter(),
+        async sharePolicy(peerId) {
+          return peerId.includes("service-worker");
+        },
+        enableRemoteHeadsGossiping: true,
+        peerId:
+          `${config.titleSuffix}-tab-${crypto.randomUUID()}` as AutomergeRepo.PeerId,
+      });
   repo.subscribeToRemotes(
     config.remoteStorageIds ?? [DEFAULT_REMOTE_STORAGE_ID]
   );
 
-  const sw = await setupServiceWorker();
-  if (!sw) throw new Error("Failed to set up service worker");
-  let activeServiceWorkerPort: MessagePort | undefined;
-  const connectServiceWorkerPort = async (port: MessagePort) => {
-    const previousPort = activeServiceWorkerPort;
-    activeServiceWorkerPort = port;
-    const net = new MessageChannelNetworkAdapter(port);
-    repo.networkSubsystem.addNetworkAdapter(net);
-    await net.whenReady();
-    previousPort?.close();
-  };
-  await sw.subscribeToRepoChannel(connectServiceWorkerPort);
+  if (hive) {
+    await repo.networkSubsystem.whenReady();
+    (hive.networkAdapter as any).syncKeyhive?.();
+  } else {
+    let activeServiceWorkerPort: MessagePort | undefined;
+    const connectServiceWorkerPort = async (port: MessagePort) => {
+      const previousPort = activeServiceWorkerPort;
+      activeServiceWorkerPort = port;
+      const net = new MessageChannelNetworkAdapter(port);
+      repo.networkSubsystem.addNetworkAdapter(net);
+      await net.whenReady();
+      previousPort?.close();
+    };
+    await sw.subscribeToRepoChannel(connectServiceWorkerPort);
+  }
 
-  installDevConsoleGlobals(repo);
-  registerPatchworkViewElement({ repo });
+  installDevConsoleGlobals(repo, hive);
+  registerPatchworkViewElement(hive ? { repo, hive } : { repo });
 
   // The watcher is started with the site's default-tools bundle alone so that
   // `resolveAccountHandle` below has something to await on (the `account`
@@ -197,6 +253,7 @@ export async function bootPatchworkSite(
 
   const accountDocHandle = await resolveAccountHandle(repo, {
     storageKey: config.accountStorageKey,
+    hive,
   });
 
   window.accountDocHandle = accountDocHandle;
@@ -255,10 +312,21 @@ function resolveDefaultModulesUrl(builtin: AutomergeUrl): AutomergeUrl {
   return builtin;
 }
 
-function installDevConsoleGlobals(repo: Repo): void {
+function installDevConsoleGlobals(
+  repo: Repo,
+  hive: AutomergeRepoKeyhive | undefined
+): void {
   window.repo = repo;
   window.Automerge = Automerge;
   window.AutomergeRepo = AutomergeRepo;
+  if (hive) {
+    window.hive = hive;
+  }
+  window.getRepoChannel = () => {
+    const { port1, port2 } = new MessageChannel();
+    navigator.serviceWorker.controller!.postMessage({ type: "port" }, [port2]);
+    return port1;
+  };
 }
 
 function onModuleLoaded(name: string, mod: any): void {

--- a/core/bootloader/src/vite/importmap-plugin.ts
+++ b/core/bootloader/src/vite/importmap-plugin.ts
@@ -45,12 +45,22 @@ export function importmap(options?: PatchworkVitePluginOptions): Plugin {
         });
       }
 
-      // Emit automerge wasm so the service worker can fetch it
-      const wasmPath = require.resolve("@automerge/automerge/automerge.wasm");
+      // Emit automerge, keyhive, and subduction wasm so the service worker can fetch them
+      const automergeWasmPath = require.resolve(
+        "@automerge/automerge/automerge.wasm"
+      );
       this.emitFile({
         type: "asset",
         fileName: "automerge.wasm",
-        source: readFileSync(wasmPath),
+        source: readFileSync(automergeWasmPath),
+      });
+      const keyhiveWasmPath = require.resolve(
+        "@keyhive/keyhive/keyhive_wasm.wasm"
+      );
+      this.emitFile({
+        type: "asset",
+        fileName: "keyhive_wasm.wasm",
+        source: readFileSync(keyhiveWasmPath),
       });
 
       // Emit subduction wasm so the service worker can fetch it

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -16,10 +16,12 @@ import {
 } from "@inkandswitch/patchwork-plugins";
 import debug from "debug";
 import { MountedEvent, NoToolEvent } from "./events.js";
+import {
+  docIdFromAutomergeUrl,
+  type initializeAutomergeRepoKeyhive,
+} from "@automerge/automerge-repo-keyhive";
 
 const log = debug("patchwork:elements:view");
-
-import type { initializeAutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 
 type AutomergeRepoKeyhive = Awaited<
   ReturnType<typeof initializeAutomergeRepoKeyhive>
@@ -49,6 +51,8 @@ export interface PatchworkViewElement extends HTMLElement {
   docUrl?: AutomergeUrl;
   toolId?: string;
 }
+
+const retryingDocs = new Set<string>();
 
 export function registerPatchworkViewElement(
   params: RegisterPatchworkViewElementParams
@@ -80,6 +84,10 @@ export function registerPatchworkViewElement(
       #state: State = State.none;
       #requestedToolImports = new Set<string>();
       #initEpoch = 0;
+      #keyhiveRetrySetup = false;
+      #handlingKeyhiveSync = false;
+      #pendingKeyhiveSync = false;
+      #unableNoAccess = false;
 
       get docUrl() {
         return this.#docUrl;
@@ -161,16 +169,48 @@ export function registerPatchworkViewElement(
 
       #init = async () => {
         const toolRegistry = getRegistry("patchwork:tool");
-        if (this.#state != State.none) {
-          return;
-        }
-
-        if (!this.docUrl) {
-          return;
-        }
+        if (this.#state != State.none) return;
+        if (!this.docUrl) return;
 
         const epoch = ++this.#initEpoch;
         this.#state = State.initializing;
+
+        // Check keyhive access to determine read/write permissions
+        let accessLevel: "None" | "Relay" | "Read" | "Edit" | "Admin"  = "None";
+
+        if (this.hive) {
+          let keyhiveDocId;
+          try {
+            keyhiveDocId = docIdFromAutomergeUrl(this.docUrl);
+          } catch {
+            accessLevel = "Edit";
+          }
+
+          if (keyhiveDocId) {
+            const bestAccess = await this.hive.bestAccessForDoc(this.hive.active.individual.id, this.docUrl);
+            accessLevel = bestAccess ? (bestAccess.toString() as typeof accessLevel) : "None";
+
+          }
+        } else {
+          accessLevel = "Edit";
+        }
+
+        // Set up keyhive sync listener
+        if (this.hive && !this.#keyhiveRetrySetup) {
+          this.#keyhiveRetrySetup = true;
+          const onKeyhiveSync = () => this.#handleKeyhiveSync();
+          (this.hive.networkAdapter as any).on("ingest-remote", onKeyhiveSync);
+          this.#teardowns.add(() => {
+            (this.hive!.networkAdapter as any).off("ingest-remote", onKeyhiveSync);
+          });
+        }
+
+        if (accessLevel === "None") {
+          console.log(`accessLevel=None for ${this.docUrl}`);
+          this.#state = State.unable;
+          this.#unableNoAccess = true;
+          return;
+        }
 
         const removeAddedListener = toolRegistry.on(
           "registered",
@@ -229,6 +269,10 @@ export function registerPatchworkViewElement(
           // If teardown ran while we were awaiting, the listener cleanup
           // already happened — silently abort.
           if (epoch !== this.#initEpoch) return;
+          if (err instanceof Error && err.message.includes("unavailable")) {
+            this.#state = State.unable;
+            return;
+          }
           throw err;
         }
 
@@ -256,11 +300,83 @@ export function registerPatchworkViewElement(
         }
 
         this.#teardowns.clear();
+        this.#keyhiveRetrySetup = false;
+        this.#unableNoAccess = false;
         this.#handle = null;
         this.#tool = null;
         this.#requestedToolImports.clear();
         this.textContent = "";
         this.#state = State.none;
+      }
+
+      async #clearDocCache() {
+        if (!this.docUrl) return;
+
+        const alreadyClearing = retryingDocs.has(this.docUrl);
+        if (alreadyClearing) return;
+
+        retryingDocs.add(this.docUrl);
+        try {
+          const documentId = String(docIdFromAutomergeUrl(this.docUrl));
+          const handle = (repo.handles as any)[documentId];
+          if (handle && handle.state === "unavailable") {
+            repo.delete(this.docUrl);
+          }
+        } catch {
+          // Ignore delete errors
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 300));
+        retryingDocs.delete(this.docUrl);
+      }
+
+      async #handleKeyhiveSync() {
+        if (!this.docUrl || !this.hive) return;
+
+        if (this.#handlingKeyhiveSync) {
+          this.#pendingKeyhiveSync = true;
+          return;
+        }
+        this.#handlingKeyhiveSync = true;
+        this.#pendingKeyhiveSync = false;
+
+        try {
+          let hasAccess = false;
+          let accessCheckSucceeded = false;
+          try {
+            const keyhiveDocId = docIdFromAutomergeUrl(this.docUrl);
+            if (keyhiveDocId) {
+              const bestAccess = await this.hive.bestAccessForDoc(
+                this.hive.active.individual.id,
+                this.docUrl
+              );
+              hasAccess = !!bestAccess;
+              accessCheckSucceeded = true;
+            } else {
+              return;
+            }
+          } catch {
+            return;
+          }
+
+          const isDisplayed = this.#state === State.rendered || this.#state === State.fallback;
+          const isUnable = this.#state === State.unable;
+
+          if (hasAccess && isUnable && this.#unableNoAccess) {
+            await this.#clearDocCache();
+            await this.#teardown();
+            await this.#init();
+          } else if (!hasAccess && isDisplayed && accessCheckSucceeded) {
+            await this.#clearDocCache();
+            await this.#teardown();
+            await this.#init();
+          }
+        } finally {
+          this.#handlingKeyhiveSync = false;
+          if (this.#pendingKeyhiveSync) {
+            this.#handleKeyhiveSync();
+          }
+        }
       }
 
       #queueRender() {
@@ -349,6 +465,7 @@ export function registerPatchworkViewElement(
           this.#state = fallingBack ? "fallback" : "rendered";
           this.dispatchEvent(new MountedEvent({ url: this.docUrl, toolId }));
         } catch (error) {
+          console.error(error);
           this.append(
             Object.assign(document.createElement("div"), {
               innerHTML: /* html */ `

--- a/core/plugins/src/account.ts
+++ b/core/plugins/src/account.ts
@@ -5,6 +5,7 @@ import {
   type Repo,
 } from "@automerge/automerge-repo";
 import type { HasPatchworkMetadata } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 import { getRegistry } from "./registry/index.js";
 import type { DatatypeDescription } from "./datatypes.js";
 import { createDocOfDatatype2 } from "./datatypes.js";
@@ -43,6 +44,7 @@ export async function resolveAccountHandle<D = AccountDoc>(
   repo: Repo,
   options: {
     storageKey: string;
+    hive?: AutomergeRepoKeyhive;
     storage?: Pick<Storage, "getItem" | "setItem">;
   }
 ): Promise<DocHandle<D & HasPatchworkMetadata>> {
@@ -60,9 +62,23 @@ export async function resolveAccountHandle<D = AccountDoc>(
     }
   }
 
+  const handle = await createAccount<D>(repo, options.hive);
+  storage.setItem(options.storageKey, handle.url);
+  return handle;
+}
+
+async function createAccount<D>(
+  repo: Repo,
+  hive: AutomergeRepoKeyhive | undefined,
+): Promise<DocHandle<D & HasPatchworkMetadata>> {
   const datatypes = getRegistry<DatatypeDescription>("patchwork:datatype");
   const accountDatatype = await datatypes.loadWhenReady("account");
-  const handle = await createDocOfDatatype2<D>(accountDatatype, repo);
-  storage.setItem(options.storageKey, handle.url);
-  return handle as DocHandle<D & HasPatchworkMetadata>;
+  const handle = await createDocOfDatatype2<D>(accountDatatype, repo, undefined, hive);
+
+  if (hive) {
+    await hive.addSyncServerRelayToDoc(handle.url);
+  }
+
+  return handle;
 }
+

--- a/core/plugins/src/datatypes.ts
+++ b/core/plugins/src/datatypes.ts
@@ -11,6 +11,7 @@ import type {
   PluginDescription,
 } from "./registry/types.js";
 import type { HasPatchworkMetadata } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 
 // Datatype implementation interface
 export type DatatypeImplementation<D = unknown> = {
@@ -42,9 +43,14 @@ export type LoadedDatatype<D = unknown> = LoadedPlugin<
 export const createDocOfDatatype2 = async <D>(
   datatype: LoadedDatatype<D>,
   repo: Repo,
-  change?: (doc: D) => void
+  change?: (doc: D) => void,
+  hive?: AutomergeRepoKeyhive
 ): Promise<DocHandle<D & HasPatchworkMetadata>> => {
   const handle = await repo.create2<D & HasPatchworkMetadata>();
+  // Add sync server with relay access
+  if (hive) {
+    await hive.addSyncServerRelayToDoc(handle.url);
+  }
   handle.change((doc) => {
     datatype.module.init(doc, repo);
     let importUrl = datatype.importUrl;
@@ -65,5 +71,6 @@ export const createDocOfDatatype2 = async <D>(
       change(doc);
     }
   });
+
   return handle;
 };

--- a/package.json
+++ b/package.json
@@ -25,18 +25,17 @@
   "pnpm": {
     "overrides": {
       "@automerge/automerge": "catalog:",
-      "@automerge/automerge-repo": "link:../automerge-repo/packages/automerge-repo",
-      "@automerge/automerge-repo-keyhive": "link:../automerge-repo-keyhive",
-      "@automerge/automerge-repo-network-messagechannel": "link:../automerge-repo/packages/automerge-repo-network-messagechannel",
-      "@automerge/automerge-repo-network-websocket": "link:../automerge-repo/packages/automerge-repo-network-websocket",
-      "@automerge/automerge-repo-react-hooks": "link:../automerge-repo/packages/automerge-repo-react-hooks",
+      "@automerge/automerge-repo": "catalog:",
+      "@automerge/automerge-repo-keyhive": "catalog:",
+      "@automerge/automerge-repo-network-messagechannel": "catalog:",
+      "@automerge/automerge-repo-network-websocket": "catalog:",
+      "@automerge/automerge-repo-react-hooks": "catalog:",
       "@automerge/automerge-repo-solid-primitives": "catalog:",
-      "@automerge/automerge-repo-storage-indexeddb": "link:../automerge-repo/packages/automerge-repo-storage-indexeddb",
-      "@automerge/automerge-repo-storage-nodefs": "link:../automerge-repo/packages/automerge-repo-storage-nodefs",
+      "@automerge/automerge-repo-storage-indexeddb": "catalog:",
       "@automerge/automerge-subduction": "catalog:",
-      "@automerge/subduction": "0.11.0",
-      "@automerge/react": "link:../automerge-repo/packages/automerge-react",
-      "@automerge/vanillajs": "link:../automerge-repo/packages/automerge-vanillajs"
+      "@automerge/react": "catalog:",
+      "@automerge/vanillajs": "catalog:",
+      "@keyhive/keyhive": "catalog:"
     }
   },
   "keywords": [],
@@ -44,7 +43,6 @@
   "devDependencies": {
     "@automerge/automerge-repo": "catalog:",
     "@automerge/automerge-subduction": "catalog:",
-    "@automerge/subduction": "0.11.0",
     "@changesets/cli": "^2.29.8",
     "@vitest/ui": "^3.2.4",
     "concurrently": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -25,15 +25,18 @@
   "pnpm": {
     "overrides": {
       "@automerge/automerge": "catalog:",
-      "@automerge/automerge-repo": "catalog:",
-      "@automerge/automerge-repo-network-messagechannel": "catalog:",
-      "@automerge/automerge-repo-network-websocket": "catalog:",
-      "@automerge/automerge-repo-react-hooks": "catalog:",
+      "@automerge/automerge-repo": "link:../automerge-repo/packages/automerge-repo",
+      "@automerge/automerge-repo-keyhive": "link:../automerge-repo-keyhive",
+      "@automerge/automerge-repo-network-messagechannel": "link:../automerge-repo/packages/automerge-repo-network-messagechannel",
+      "@automerge/automerge-repo-network-websocket": "link:../automerge-repo/packages/automerge-repo-network-websocket",
+      "@automerge/automerge-repo-react-hooks": "link:../automerge-repo/packages/automerge-repo-react-hooks",
       "@automerge/automerge-repo-solid-primitives": "catalog:",
-      "@automerge/automerge-repo-storage-indexeddb": "catalog:",
+      "@automerge/automerge-repo-storage-indexeddb": "link:../automerge-repo/packages/automerge-repo-storage-indexeddb",
+      "@automerge/automerge-repo-storage-nodefs": "link:../automerge-repo/packages/automerge-repo-storage-nodefs",
       "@automerge/automerge-subduction": "catalog:",
-      "@automerge/react": "catalog:",
-      "@automerge/vanillajs": "catalog:"
+      "@automerge/subduction": "0.11.0",
+      "@automerge/react": "link:../automerge-repo/packages/automerge-react",
+      "@automerge/vanillajs": "link:../automerge-repo/packages/automerge-vanillajs"
     }
   },
   "keywords": [],
@@ -41,6 +44,7 @@
   "devDependencies": {
     "@automerge/automerge-repo": "catalog:",
     "@automerge/automerge-subduction": "catalog:",
+    "@automerge/subduction": "0.11.0",
     "@changesets/cli": "^2.29.8",
     "@vitest/ui": "^3.2.4",
     "concurrently": "^9.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
 overrides:
   '@automerge/automerge': 3.2.6
   '@automerge/automerge-repo': 2.6.0-subduction.22
-  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.3
+  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.4
   '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.22
   '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.22
   '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.22
@@ -130,8 +130,8 @@ importers:
         version: 0.1.4
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.3
-        version: 0.3.0-alpha.sub.3(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.4
+        version: 0.3.0-alpha.sub.4(ws@8.18.3)
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -149,8 +149,8 @@ importers:
         specifier: 2.6.0-subduction.22
         version: 2.6.0-subduction.22
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.3
-        version: 0.3.0-alpha.sub.3(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.4
+        version: 0.3.0-alpha.sub.4(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -220,8 +220,8 @@ importers:
         specifier: 2.6.0-subduction.22
         version: 2.6.0-subduction.22
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.3
-        version: 0.3.0-alpha.sub.3(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.4
+        version: 0.3.0-alpha.sub.4(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -470,8 +470,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.3
-        version: 0.3.0-alpha.sub.3(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.4
+        version: 0.3.0-alpha.sub.4(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -555,8 +555,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.3
-        version: 0.3.0-alpha.sub.3(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.4
+        version: 0.3.0-alpha.sub.4(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -596,8 +596,8 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.3':
-    resolution: {integrity: sha512-+uUm1IRIcPkSxSgB1tROBfxSSyvuA6z/TbLIb9eoO7GW9rMZ4mx10JCZz5cqFCz/NznVmLeVj9x1WlVav2Zmfw==}
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.4':
+    resolution: {integrity: sha512-Re/nxxsVuOS1dvqKA8ANxRNy6vCh8rpu8mpGPlx1M4ya7OmBiBvJvcrRWEmO1wiOdVBjlhf0t4ewyzbFA1gV8A==}
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.22':
     resolution: {integrity: sha512-kFnwo+29mywzMsa1cjopJrtzpvTAMOVJdKAdmQhlHcVk7a3pR95Gtkrb0ilgSN1otKBjd/on6w+8ED01skuinw==}
@@ -3352,7 +3352,7 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.3(ws@8.18.3)':
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.4(ws@8.18.3)':
     dependencies:
       '@automerge/automerge-repo': 2.6.0-subduction.22
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.22

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   '@automerge/automerge-subduction': 0.13.0
   '@automerge/react': 2.6.0-subduction.21
   '@automerge/vanillajs': 2.6.0-subduction.21
-  '@keyhive/keyhive': 0.0.0-alpha.58
+  '@keyhive/keyhive': 0.0.0-alpha.56
 
 importers:
 
@@ -111,8 +111,8 @@ importers:
         specifier: workspace:^
         version: link:../plugins
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.56
+        version: 0.0.0-alpha.56
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -479,8 +479,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.56
+        version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.58
-        version: 0.0.0-alpha.58
+        specifier: 0.0.0-alpha.56
+        version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -1440,8 +1440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@keyhive/keyhive@0.0.0-alpha.58':
-    resolution: {integrity: sha512-AKwJVk+2+vF2oxe59yIT1eNQXWAmugkmduQR6vzpgg68bbrczptN/mKmaVJL1fVv29lqaFAEFfQI24k7C3p0TA==}
+  '@keyhive/keyhive@0.0.0-alpha.56':
+    resolution: {integrity: sha512-hx/MRkRqCSJFIh5jHKs9HkzDQy4tUZzgaRlc85+8t22VciubmZAU1FyugmYboskPUxUGwqZC1GarwXfxhrp5DA==}
 
   '@lezer/common@1.3.0':
     resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
@@ -3353,7 +3353,7 @@ snapshots:
       '@automerge/automerge-repo': 2.6.0-subduction.21
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
       '@automerge/automerge-subduction': 0.13.0
-      '@keyhive/keyhive': 0.0.0-alpha.58
+      '@keyhive/keyhive': 0.0.0-alpha.56
       cbor-x: 1.6.4
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.18.3)
@@ -4046,7 +4046,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@keyhive/keyhive@0.0.0-alpha.58': {}
+  '@keyhive/keyhive@0.0.0-alpha.56': {}
 
   '@lezer/common@1.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,17 +21,17 @@ catalogs:
 
 overrides:
   '@automerge/automerge': 3.2.6
-  '@automerge/automerge-repo': 2.6.0-subduction.21
-  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.1
-  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.21
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
-  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.21
-  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.21
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.21
+  '@automerge/automerge-repo': 2.6.0-subduction.22
+  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.3
+  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.22
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.22
+  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.22
+  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.22
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.22
   '@automerge/automerge-subduction': 0.13.0
-  '@automerge/react': 2.6.0-subduction.21
-  '@automerge/vanillajs': 2.6.0-subduction.21
-  '@keyhive/keyhive': 0.0.0-alpha.56
+  '@automerge/react': 2.6.0-subduction.22
+  '@automerge/vanillajs': 2.6.0-subduction.22
+  '@keyhive/keyhive': 0.0.0-alpha.58b
 
 importers:
 
@@ -45,8 +45,8 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-subduction':
         specifier: 0.13.0
         version: 0.13.0
@@ -84,23 +84,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-subduction':
         specifier: 0.13.0
         version: 0.13.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../elements
@@ -111,8 +111,8 @@ importers:
         specifier: workspace:^
         version: link:../plugins
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58b
+        version: 0.0.0-alpha.58b
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -130,8 +130,8 @@ importers:
         version: 0.1.4
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.1
-        version: 0.3.0-alpha.sub.1(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.3
+        version: 0.3.0-alpha.sub.3(ws@8.18.3)
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -146,11 +146,11 @@ importers:
         version: 4.4.3
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.1
-        version: 0.3.0-alpha.sub.1(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.3
+        version: 0.3.0-alpha.sub.3(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -170,8 +170,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -186,8 +186,8 @@ importers:
         version: 2.0.3
     devDependencies:
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-subduction':
         specifier: 0.13.0
         version: 0.13.0
@@ -217,11 +217,11 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.1
-        version: 0.3.0-alpha.sub.1(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.3
+        version: 0.3.0-alpha.sub.3(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -242,8 +242,8 @@ importers:
         version: link:../../../subscribables/core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -264,8 +264,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -283,8 +283,8 @@ importers:
         version: link:../../../subscribables/core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -296,8 +296,8 @@ importers:
         version: link:../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -321,8 +321,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -333,11 +333,11 @@ importers:
   packages/react:
     devDependencies:
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -361,8 +361,8 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.1
@@ -373,8 +373,8 @@ importers:
   packages/solid:
     dependencies:
       '@automerge/automerge-repo-solid-primitives':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21(@automerge/automerge@3.2.6)(solid-js@1.9.9)
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22(@automerge/automerge@3.2.6)(solid-js@1.9.9)
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -427,23 +427,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-subduction':
         specifier: 0.13.0
         version: 0.13.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@codemirror/language':
         specifier: ^6.11.3
         version: 6.11.3
@@ -470,8 +470,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.1
-        version: 0.3.0-alpha.sub.1(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.3
+        version: 0.3.0-alpha.sub.3(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -479,8 +479,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58b
+        version: 0.0.0-alpha.58b
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -512,23 +512,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@automerge/automerge-subduction':
         specifier: 0.13.0
         version: 0.13.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.21
-        version: 2.6.0-subduction.21
+        specifier: 2.6.0-subduction.22
+        version: 2.6.0-subduction.22
       '@codemirror/language':
         specifier: ^6.11.3
         version: 6.11.3
@@ -555,8 +555,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 0.3.0-alpha.sub.1
-        version: 0.3.0-alpha.sub.1(ws@8.18.3)
+        specifier: 0.3.0-alpha.sub.3
+        version: 0.3.0-alpha.sub.3(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58b
+        version: 0.0.0-alpha.58b
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -596,35 +596,35 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1':
-    resolution: {integrity: sha512-ctbVNLketU4Z22Mc+o4MJtE4s6tIPGswO53uVweI8l5yFYYYfGORDEjwlgHHPgYT7whoRB7kNiY3X9F2bvVRjQ==}
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.3':
+    resolution: {integrity: sha512-+uUm1IRIcPkSxSgB1tROBfxSSyvuA6z/TbLIb9eoO7GW9rMZ4mx10JCZz5cqFCz/NznVmLeVj9x1WlVav2Zmfw==}
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.21':
-    resolution: {integrity: sha512-o49ee9SCo6w/5M5MycJhz0RAHhYxB2iQPPjFS/ofe7mMwk3DykePKW3zWOhuCH0Mpzt21kVJpRpBUtHvF5O4Yw==}
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.22':
+    resolution: {integrity: sha512-kFnwo+29mywzMsa1cjopJrtzpvTAMOVJdKAdmQhlHcVk7a3pR95Gtkrb0ilgSN1otKBjd/on6w+8ED01skuinw==}
 
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.21':
-    resolution: {integrity: sha512-pSZNzfx8cnpEapJhYCHY9qHOpLuNfcHpM0LqTApdyOHwUs94FRWQff79KmhnFLob94WCBOA5xaKkNkrUom3AuQ==}
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.22':
+    resolution: {integrity: sha512-/qRDktH+IqFmbjJZwb4zONlpvj+SPi8hVlkRRcLI5kR4VXfQpmBHnVQyRsfXqW5Pd/ZtcuBUqWfQQ6G5Y7iNuA==}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.21':
-    resolution: {integrity: sha512-9advk34JgRvBRLtSnMIrP4jhkC6eKB2bbH+v/q+zsRLkk3vrdTxQCWcuh1LqdbF3U8DEZmIjU9M7pYumS9Mwaw==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.22':
+    resolution: {integrity: sha512-CNWUC4GENECSqURLbT7bZmr3IE16rCSMBjWzUyhxlxvOAAKSiqZs+hUfgysxtDTPJ4cQdZdmJmaQ1KDtYBmePg==}
 
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.21':
-    resolution: {integrity: sha512-WLZ5NV8+7eCcF/xkg1kVDUmkxYMhJelsyiKHuHl4LuT1XJa8s2TTlITbMLCEel4KaLUFzNRqCbi4lgf7KW51VQ==}
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.22':
+    resolution: {integrity: sha512-VjFs4ub71VLP5XNTHRuT6h/Q54XOp9nUo2oym7N3828z8m4wkQdp8VYRAnqcuJ0eq3PP1lTbiVYL5QnEDcqJ6Q==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.21':
-    resolution: {integrity: sha512-oWVEQtzGOV8uT6ZDc3DbbbmD+yMpkg1tzjql7sX6oIIYMmdPcVM4SEdhU7GEIQhXgdnp/c+BePqjaVD1niPRvw==}
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.22':
+    resolution: {integrity: sha512-oZ8pINLxJehvgZcu6qzvEWbrWgb0Hxn/UnAQ0D37YNtxCsdsa23JCnIAtiGVKmWid+y1V+VlvLUmEPZ/ri5dFg==}
     peerDependencies:
       '@automerge/automerge': 3.2.6
       solid-js: ^1.9.4
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.21':
-    resolution: {integrity: sha512-jPP/v/6cbyly0jNt9bO8xTA4ONrwNsaTw4ZUh+K1Z/oLtXO4J5BKmDVHKNQdwsiFRkh/2480FBd6mQGeWzF/FQ==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.22':
+    resolution: {integrity: sha512-ooQSTAmBPH6I7vDySMB0RtKhVV28922MHrwrL9uQ84s/oHkGUQDg9X+5o04/ozC5AW/tujgvZPNxqzSNKXWc1A==}
 
-  '@automerge/automerge-repo@2.6.0-subduction.21':
-    resolution: {integrity: sha512-MG9v9c7z0zrGmXpdwkeuSiOcdAO+vmPp857WoJrECBG6au0uKJqXszndahLZYXUoolZw3TvByVAOe7Swosft+w==}
+  '@automerge/automerge-repo@2.6.0-subduction.22':
+    resolution: {integrity: sha512-BxNJQPtutS8wFu14AADDHxKqpnYJxNMgYmgZqW1RBnje2/TXxqs8jJLwWKluAlPN7AsVT3CLJheoXla20VhqcA==}
 
   '@automerge/automerge-subduction@0.13.0':
     resolution: {integrity: sha512-7XlCIS0GH3ctboE8UPmD9rfiv203Q8n5Lx63xE6xCgtlpwecDKqzLDp77e9hUEo76j17Y8bYQyfsROqaByLf5A==}
@@ -632,8 +632,8 @@ packages:
   '@automerge/automerge@3.2.6':
     resolution: {integrity: sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==}
 
-  '@automerge/vanillajs@2.6.0-subduction.21':
-    resolution: {integrity: sha512-sncO4petovCJpDEiHCw9JrVjrM+AQQNeahgNLJ63k88ZYX1KfMjCWuQP1UIrVQ7q46EpwIXlI9d5EPQazd7Jqg==}
+  '@automerge/vanillajs@2.6.0-subduction.22':
+    resolution: {integrity: sha512-JTWYEhpfb0mjl5sMuMetzpJTw97CLuYygF52JeALF9ZQleTElbh0wa8wLyAPAEa7xQgDIYScRUAvqyaCrRZb7A==}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
@@ -1440,8 +1440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@keyhive/keyhive@0.0.0-alpha.56':
-    resolution: {integrity: sha512-hx/MRkRqCSJFIh5jHKs9HkzDQy4tUZzgaRlc85+8t22VciubmZAU1FyugmYboskPUxUGwqZC1GarwXfxhrp5DA==}
+  '@keyhive/keyhive@0.0.0-alpha.58b':
+    resolution: {integrity: sha512-WAQorh73QDZYIVYukoaAGC3oyj2nqVk7XwrTHIr/wzbAnjqtuyKxaVfvSJ40YeR+R7divpJZysIfGIbOpE6RLA==}
 
   '@lezer/common@1.3.0':
     resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
@@ -1464,6 +1464,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3348,12 +3352,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1(ws@8.18.3)':
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.3(ws@8.18.3)':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.22
       '@automerge/automerge-subduction': 0.13.0
-      '@keyhive/keyhive': 0.0.0-alpha.56
+      '@keyhive/keyhive': 0.0.0-alpha.58b
+      '@noble/hashes': 2.2.0
       cbor-x: 1.6.4
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.18.3)
@@ -3363,17 +3368,17 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.21':
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.22':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.21':
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.22':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
       debug: 4.4.3
       eventemitter3: 5.0.1
     transitivePeerDependencies:
@@ -3381,9 +3386,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.21':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.22':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
       cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.1
@@ -3394,10 +3399,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@automerge/automerge': 3.2.6
-      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
       eventemitter3: 5.0.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3407,20 +3412,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.21(@automerge/automerge@3.2.6)(solid-js@1.9.9)':
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.22(@automerge/automerge@3.2.6)(solid-js@1.9.9)':
     dependencies:
       '@automerge/automerge': 3.2.6
       solid-js: 1.9.9
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.21':
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.22':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.21':
+  '@automerge/automerge-repo@2.6.0-subduction.22':
     dependencies:
       '@automerge/automerge': 3.2.6
       '@automerge/automerge-subduction': 0.13.0
@@ -3442,13 +3447,13 @@ snapshots:
 
   '@automerge/automerge@3.2.6': {}
 
-  '@automerge/vanillajs@2.6.0-subduction.21':
+  '@automerge/vanillajs@2.6.0-subduction.22':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.21
-      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.21
-      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.21
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
-      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.21
+      '@automerge/automerge-repo': 2.6.0-subduction.22
+      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.22
+      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.22
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.22
+      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.22
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4046,7 +4051,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@keyhive/keyhive@0.0.0-alpha.56': {}
+  '@keyhive/keyhive@0.0.0-alpha.58b': {}
 
   '@lezer/common@1.3.0': {}
 
@@ -4077,6 +4082,8 @@ snapshots:
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   '@automerge/automerge-subduction': 0.13.0
   '@automerge/react': 2.6.0-subduction.21
   '@automerge/vanillajs': 2.6.0-subduction.21
-  '@keyhive/keyhive': 0.0.0-alpha.56
+  '@keyhive/keyhive': 0.0.0-alpha.58
 
 importers:
 
@@ -111,8 +111,8 @@ importers:
         specifier: workspace:^
         version: link:../plugins
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58
+        version: 0.0.0-alpha.58
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -479,8 +479,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58
+        version: 0.0.0-alpha.58
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 0.0.0-alpha.56
-        version: 0.0.0-alpha.56
+        specifier: 0.0.0-alpha.58
+        version: 0.0.0-alpha.58
       '@tailwindcss/vite':
         specifier: ^4.1.14
         version: 4.1.15(vite@7.1.11(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
@@ -1440,8 +1440,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@keyhive/keyhive@0.0.0-alpha.56':
-    resolution: {integrity: sha512-hx/MRkRqCSJFIh5jHKs9HkzDQy4tUZzgaRlc85+8t22VciubmZAU1FyugmYboskPUxUGwqZC1GarwXfxhrp5DA==}
+  '@keyhive/keyhive@0.0.0-alpha.58':
+    resolution: {integrity: sha512-AKwJVk+2+vF2oxe59yIT1eNQXWAmugkmduQR6vzpgg68bbrczptN/mKmaVJL1fVv29lqaFAEFfQI24k7C3p0TA==}
 
   '@lezer/common@1.3.0':
     resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
@@ -3353,7 +3353,7 @@ snapshots:
       '@automerge/automerge-repo': 2.6.0-subduction.21
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
       '@automerge/automerge-subduction': 0.13.0
-      '@keyhive/keyhive': 0.0.0-alpha.56
+      '@keyhive/keyhive': 0.0.0-alpha.58
       cbor-x: 1.6.4
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.18.3)
@@ -4046,7 +4046,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@keyhive/keyhive@0.0.0-alpha.56': {}
+  '@keyhive/keyhive@0.0.0-alpha.58': {}
 
   '@lezer/common@1.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@keyhive/keyhive':
-      specifier: 0.0.0-alpha.56
-      version: 0.0.0-alpha.56
     '@types/react':
       specifier: 18.3.1
       version: 18.3.1
@@ -24,18 +21,17 @@ catalogs:
 
 overrides:
   '@automerge/automerge': 3.2.6
-  '@automerge/automerge-repo': link:../automerge-repo/packages/automerge-repo
-  '@automerge/automerge-repo-keyhive': link:../automerge-repo-keyhive
-  '@automerge/automerge-repo-network-messagechannel': link:../automerge-repo/packages/automerge-repo-network-messagechannel
-  '@automerge/automerge-repo-network-websocket': link:../automerge-repo/packages/automerge-repo-network-websocket
-  '@automerge/automerge-repo-react-hooks': link:../automerge-repo/packages/automerge-repo-react-hooks
-  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.20
-  '@automerge/automerge-repo-storage-indexeddb': link:../automerge-repo/packages/automerge-repo-storage-indexeddb
-  '@automerge/automerge-repo-storage-nodefs': link:../automerge-repo/packages/automerge-repo-storage-nodefs
-  '@automerge/automerge-subduction': 0.12.1
-  '@automerge/subduction': 0.11.0
-  '@automerge/react': link:../automerge-repo/packages/automerge-react
-  '@automerge/vanillajs': link:../automerge-repo/packages/automerge-vanillajs
+  '@automerge/automerge-repo': 2.6.0-subduction.21
+  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.1
+  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.21
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
+  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.21
+  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.21
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.21
+  '@automerge/automerge-subduction': 0.13.0
+  '@automerge/react': 2.6.0-subduction.21
+  '@automerge/vanillajs': 2.6.0-subduction.21
+  '@keyhive/keyhive': 0.0.0-alpha.56
 
 importers:
 
@@ -49,14 +45,11 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: link:../automerge-repo/packages/automerge-repo
-        version: link:../automerge-repo/packages/automerge-repo
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
-      '@automerge/subduction':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.13.0
+        version: 0.13.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@24.9.1)
@@ -91,26 +84,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
-      '@automerge/automerge-repo-keyhive':
-        specifier: link:../../../automerge-repo-keyhive
-        version: link:../../../automerge-repo-keyhive
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
-        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-network-websocket':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-network-websocket
-        version: link:../../../automerge-repo/packages/automerge-repo-network-websocket
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
-        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
-        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
-        version: link:../../../automerge-repo/packages/automerge-vanillajs
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../elements
@@ -121,7 +111,7 @@ importers:
         specifier: workspace:^
         version: link:../plugins
       '@keyhive/keyhive':
-        specifier: 'catalog:'
+        specifier: 0.0.0-alpha.56
         version: 0.0.0-alpha.56
       '@types/debug':
         specifier: ^4.1.12
@@ -139,6 +129,9 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4
     devDependencies:
+      '@automerge/automerge-repo-keyhive':
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -148,16 +141,16 @@ importers:
 
   core/elements:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
       debug:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-keyhive':
-        specifier: link:../../../automerge-repo-keyhive
-        version: link:../../../automerge-repo-keyhive
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -177,8 +170,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -193,20 +186,17 @@ importers:
         version: 2.0.3
     devDependencies:
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
-        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
 
   core/plugins:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -226,9 +216,12 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-keyhive':
-        specifier: link:../../../automerge-repo-keyhive
-        version: link:../../../automerge-repo-keyhive
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -238,9 +231,6 @@ importers:
 
   packages/annotations/annotation-types/comments:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../../../automerge-repo/packages/automerge-repo
-        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -251,15 +241,15 @@ importers:
         specifier: workspace:*
         version: link:../../../subscribables/core
     devDependencies:
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
 
   packages/annotations/annotation-types/diff:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../../../automerge-repo/packages/automerge-repo
-        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -273,15 +263,15 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
 
   packages/annotations/annotation-types/selection:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../../../automerge-repo/packages/automerge-repo
-        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -292,6 +282,9 @@ importers:
         specifier: workspace:*
         version: link:../../../subscribables/core
     devDependencies:
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -303,8 +296,8 @@ importers:
         version: link:../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: link:../../../../automerge-repo/packages/automerge-repo
-        version: link:../../../../automerge-repo/packages/automerge-repo
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -317,9 +310,6 @@ importers:
 
   packages/annotations/core:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../../automerge-repo/packages/automerge-repo
-        version: link:../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/subscribables':
         specifier: workspace:*
         version: link:../../subscribables/core
@@ -330,6 +320,9 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -338,14 +331,13 @@ importers:
         version: 2.1.9(@types/node@24.9.1)(@vitest/ui@3.2.4(vitest@3.2.4))(happy-dom@20.8.9)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
 
   packages/react:
-    dependencies:
-      '@automerge/automerge-repo-react-hooks':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
-        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
-      '@automerge/vanillajs':
-        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
-        version: link:../../../automerge-repo/packages/automerge-vanillajs
     devDependencies:
+      '@automerge/automerge-repo-react-hooks':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@automerge/vanillajs':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -364,13 +356,13 @@ importers:
 
   packages/refs-react:
     dependencies:
-      '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
       react:
         specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.1
@@ -381,8 +373,8 @@ importers:
   packages/solid:
     dependencies:
       '@automerge/automerge-repo-solid-primitives':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20(@automerge/automerge@3.2.6)(solid-js@1.9.9)
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21(@automerge/automerge@3.2.6)(solid-js@1.9.9)
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -435,23 +427,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
-        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-react-hooks':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
-        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
-        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
-        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
-        version: link:../../../automerge-repo/packages/automerge-vanillajs
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@codemirror/language':
         specifier: ^6.11.3
         version: 6.11.3
@@ -478,8 +470,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: link:../../../automerge-repo-keyhive
-        version: link:../../../automerge-repo-keyhive
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -487,7 +479,7 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 'catalog:'
+        specifier: 0.0.0-alpha.56
         version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
@@ -520,23 +512,23 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: link:../../../automerge-repo/packages/automerge-repo
-        version: link:../../../automerge-repo/packages/automerge-repo
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
-        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-repo-react-hooks':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
-        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
-        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
-        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
-        version: link:../../../automerge-repo/packages/automerge-vanillajs
+        specifier: 2.6.0-subduction.21
+        version: 2.6.0-subduction.21
       '@codemirror/language':
         specifier: ^6.11.3
         version: 6.11.3
@@ -563,8 +555,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: link:../../../automerge-repo-keyhive
-        version: link:../../../automerge-repo-keyhive
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -572,7 +564,7 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 'catalog:'
+        specifier: 0.0.0-alpha.56
         version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
@@ -604,24 +596,78 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.20':
-    resolution: {integrity: sha512-NQsgpqLb4fVfvzUMAZ2m5mvi657d4OOxdiXTxkeNmV49ll1BWmxfBmfGSBrLJHleldDH0Ev0GcXsq8KvVNf36Q==}
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1':
+    resolution: {integrity: sha512-ctbVNLketU4Z22Mc+o4MJtE4s6tIPGswO53uVweI8l5yFYYYfGORDEjwlgHHPgYT7whoRB7kNiY3X9F2bvVRjQ==}
+
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.21':
+    resolution: {integrity: sha512-o49ee9SCo6w/5M5MycJhz0RAHhYxB2iQPPjFS/ofe7mMwk3DykePKW3zWOhuCH0Mpzt21kVJpRpBUtHvF5O4Yw==}
+
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.21':
+    resolution: {integrity: sha512-pSZNzfx8cnpEapJhYCHY9qHOpLuNfcHpM0LqTApdyOHwUs94FRWQff79KmhnFLob94WCBOA5xaKkNkrUom3AuQ==}
+
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.21':
+    resolution: {integrity: sha512-9advk34JgRvBRLtSnMIrP4jhkC6eKB2bbH+v/q+zsRLkk3vrdTxQCWcuh1LqdbF3U8DEZmIjU9M7pYumS9Mwaw==}
+
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.21':
+    resolution: {integrity: sha512-WLZ5NV8+7eCcF/xkg1kVDUmkxYMhJelsyiKHuHl4LuT1XJa8s2TTlITbMLCEel4KaLUFzNRqCbi4lgf7KW51VQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.21':
+    resolution: {integrity: sha512-oWVEQtzGOV8uT6ZDc3DbbbmD+yMpkg1tzjql7sX6oIIYMmdPcVM4SEdhU7GEIQhXgdnp/c+BePqjaVD1niPRvw==}
     peerDependencies:
       '@automerge/automerge': 3.2.6
       solid-js: ^1.9.4
 
-  '@automerge/automerge-subduction@0.12.1':
-    resolution: {integrity: sha512-s1s40RTozkqExIk1LYdogKPzpCMFfe/7KBS0ccAlwsy4JwdcUGG9NQO2Pm3kZq8vD3OPw7DcIOSPG+bnLESQFg==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.21':
+    resolution: {integrity: sha512-jPP/v/6cbyly0jNt9bO8xTA4ONrwNsaTw4ZUh+K1Z/oLtXO4J5BKmDVHKNQdwsiFRkh/2480FBd6mQGeWzF/FQ==}
+
+  '@automerge/automerge-repo@2.6.0-subduction.21':
+    resolution: {integrity: sha512-MG9v9c7z0zrGmXpdwkeuSiOcdAO+vmPp857WoJrECBG6au0uKJqXszndahLZYXUoolZw3TvByVAOe7Swosft+w==}
+
+  '@automerge/automerge-subduction@0.13.0':
+    resolution: {integrity: sha512-7XlCIS0GH3ctboE8UPmD9rfiv203Q8n5Lx63xE6xCgtlpwecDKqzLDp77e9hUEo76j17Y8bYQyfsROqaByLf5A==}
 
   '@automerge/automerge@3.2.6':
     resolution: {integrity: sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==}
 
-  '@automerge/subduction@0.11.0':
-    resolution: {integrity: sha512-32GzWTuOA6htRXKA/KYZ33y9TZUazXjr9oQxuNZZwtkGoKnT1Vr1URLoEZj8LVX3oIwCZH6ZjkAXteUqDTG/+Q==}
+  '@automerge/vanillajs@2.6.0-subduction.21':
+    resolution: {integrity: sha512-sncO4petovCJpDEiHCw9JrVjrM+AQQNeahgNLJ63k88ZYX1KfMjCWuQP1UIrVQ7q46EpwIXlI9d5EPQazd7Jqg==}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
+    cpu: [x64]
+    os: [win32]
 
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
@@ -1415,6 +1461,10 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1861,6 +1911,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1875,6 +1928,12 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+
+  bs58check@3.0.1:
+    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1885,6 +1944,13 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  cbor-extract@2.2.2:
+    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
+    hasBin: true
+
+  cbor-x@1.6.4:
+    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -2119,6 +2185,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2280,6 +2349,11 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2536,6 +2610,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
@@ -2657,6 +2735,11 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-usestateref@1.0.9:
+    resolution: {integrity: sha512-t8KLsI7oje0HzfzGhxFXzuwbf1z9vhBM1ptHLUIHhYqZDKFuI5tzdhEVxSNzUkYxwF8XdpOErzHlKxvP7sTERw==}
+    peerDependencies:
+      react: '>16.0.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2938,6 +3021,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -3231,6 +3319,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xstate@5.31.1:
+    resolution: {integrity: sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3257,18 +3348,131 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.20(@automerge/automerge@3.2.6)(solid-js@1.9.9)':
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1(ws@8.18.3)':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
+      '@automerge/automerge-subduction': 0.13.0
+      '@keyhive/keyhive': 0.0.0-alpha.56
+      cbor-x: 1.6.4
+      eventemitter3: 5.0.1
+      isomorphic-ws: 5.0.0(ws@8.18.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+      debug: 4.4.3
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.1
+      isomorphic-ws: 5.0.0(ws@8.18.3)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@automerge/automerge': 3.2.6
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+      eventemitter3: 5.0.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-usestateref: 1.0.9(react@18.3.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.21(@automerge/automerge@3.2.6)(solid-js@1.9.9)':
     dependencies:
       '@automerge/automerge': 3.2.6
       solid-js: 1.9.9
 
-  '@automerge/automerge-subduction@0.12.1': {}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-repo@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge': 3.2.6
+      '@automerge/automerge-subduction': 0.13.0
+      bs58check: 3.0.1
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.1
+      fast-sha256: 1.3.0
+      isomorphic-ws: 5.0.0(ws@8.18.3)
+      uuid: 9.0.1
+      ws: 8.18.3
+      xstate: 5.31.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@automerge/automerge-subduction@0.13.0': {}
 
   '@automerge/automerge@3.2.6': {}
 
-  '@automerge/subduction@0.11.0': {}
+  '@automerge/vanillajs@2.6.0-subduction.21':
+    dependencies:
+      '@automerge/automerge-repo': 2.6.0-subduction.21
+      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.21
+      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.21
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.21
+      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.21
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@babel/runtime@7.28.4': {}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    optional: true
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -3872,6 +4076,8 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4303,6 +4509,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base-x@4.0.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -4320,12 +4528,37 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  bs58@5.0.0:
+    dependencies:
+      base-x: 4.0.1
+
+  bs58check@3.0.1:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 5.0.0
+
   buffer-from@1.1.2:
     optional: true
 
   cac@6.7.14: {}
 
   callsites@3.1.0: {}
+
+  cbor-extract@2.2.2:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
+    optional: true
+
+  cbor-x@1.6.4:
+    optionalDependencies:
+      cbor-extract: 2.2.2
 
   chai@5.3.3:
     dependencies:
@@ -4653,6 +4886,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -4805,6 +5040,10 @@ snapshots:
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
 
   jiti@2.6.1: {}
 
@@ -5015,6 +5254,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
   nwsapi@2.2.22: {}
 
   optionator@0.9.4:
@@ -5113,6 +5357,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-usestateref@1.0.9(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:
@@ -5369,6 +5617,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@9.0.1: {}
 
   vite-node@2.1.9(@types/node@24.9.1)(lightningcss@1.32.0)(terser@5.44.0):
     dependencies:
@@ -5688,6 +5938,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xstate@5.31.1: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@automerge/automerge-repo-keyhive':
-      specifier: 0.2.0-alpha.1d
-      version: 0.2.0-alpha.1d
     '@keyhive/keyhive':
       specifier: 0.0.0-alpha.56
       version: 0.0.0-alpha.56
@@ -27,15 +24,18 @@ catalogs:
 
 overrides:
   '@automerge/automerge': 3.2.6
-  '@automerge/automerge-repo': 2.6.0-subduction.20
-  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.20
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.20
-  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.20
+  '@automerge/automerge-repo': link:../automerge-repo/packages/automerge-repo
+  '@automerge/automerge-repo-keyhive': link:../automerge-repo-keyhive
+  '@automerge/automerge-repo-network-messagechannel': link:../automerge-repo/packages/automerge-repo-network-messagechannel
+  '@automerge/automerge-repo-network-websocket': link:../automerge-repo/packages/automerge-repo-network-websocket
+  '@automerge/automerge-repo-react-hooks': link:../automerge-repo/packages/automerge-repo-react-hooks
   '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.20
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.20
+  '@automerge/automerge-repo-storage-indexeddb': link:../automerge-repo/packages/automerge-repo-storage-indexeddb
+  '@automerge/automerge-repo-storage-nodefs': link:../automerge-repo/packages/automerge-repo-storage-nodefs
   '@automerge/automerge-subduction': 0.12.1
-  '@automerge/react': 2.6.0-subduction.20
-  '@automerge/vanillajs': 2.6.0-subduction.20
+  '@automerge/subduction': 0.11.0
+  '@automerge/react': link:../automerge-repo/packages/automerge-react
+  '@automerge/vanillajs': link:../automerge-repo/packages/automerge-vanillajs
 
 importers:
 
@@ -49,11 +49,14 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../automerge-repo/packages/automerge-repo
+        version: link:../automerge-repo/packages/automerge-repo
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1
+      '@automerge/subduction':
+        specifier: 0.11.0
+        version: 0.11.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@24.9.1)
@@ -88,23 +91,26 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
+      '@automerge/automerge-repo-keyhive':
+        specifier: link:../../../automerge-repo-keyhive
+        version: link:../../../automerge-repo-keyhive
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-network-websocket
+        version: link:../../../automerge-repo/packages/automerge-repo-network-websocket
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
+        version: link:../../../automerge-repo/packages/automerge-vanillajs
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../elements
@@ -114,6 +120,9 @@ importers:
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../plugins
+      '@keyhive/keyhive':
+        specifier: 'catalog:'
+        version: 0.0.0-alpha.56
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -130,9 +139,6 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4
     devDependencies:
-      '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -142,16 +148,16 @@ importers:
 
   core/elements:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       debug:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: link:../../../automerge-repo-keyhive
+        version: link:../../../automerge-repo-keyhive
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -171,8 +177,8 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -187,8 +193,8 @@ importers:
         version: 2.0.3
     devDependencies:
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1
@@ -198,6 +204,9 @@ importers:
 
   core/plugins:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -217,12 +226,9 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: link:../../../automerge-repo-keyhive
+        version: link:../../../automerge-repo-keyhive
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -232,6 +238,9 @@ importers:
 
   packages/annotations/annotation-types/comments:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../../../automerge-repo/packages/automerge-repo
+        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -242,15 +251,15 @@ importers:
         specifier: workspace:*
         version: link:../../../subscribables/core
     devDependencies:
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
 
   packages/annotations/annotation-types/diff:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../../../automerge-repo/packages/automerge-repo
+        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -264,15 +273,15 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
 
   packages/annotations/annotation-types/selection:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../../../automerge-repo/packages/automerge-repo
+        version: link:../../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/annotations':
         specifier: workspace:*
         version: link:../../core
@@ -283,9 +292,6 @@ importers:
         specifier: workspace:*
         version: link:../../../subscribables/core
     devDependencies:
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -297,8 +303,8 @@ importers:
         version: link:../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../../automerge-repo/packages/automerge-repo
+        version: link:../../../../automerge-repo/packages/automerge-repo
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -311,6 +317,9 @@ importers:
 
   packages/annotations/core:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../../automerge-repo/packages/automerge-repo
+        version: link:../../../../automerge-repo/packages/automerge-repo
       '@inkandswitch/subscribables':
         specifier: workspace:*
         version: link:../../subscribables/core
@@ -321,9 +330,6 @@ importers:
       '@automerge/automerge':
         specifier: 3.2.6
         version: 3.2.6
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -332,13 +338,14 @@ importers:
         version: 2.1.9(@types/node@24.9.1)(@vitest/ui@3.2.4(vitest@3.2.4))(happy-dom@20.8.9)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
 
   packages/react:
-    devDependencies:
+    dependencies:
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
+        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
+        version: link:../../../automerge-repo/packages/automerge-vanillajs
+    devDependencies:
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -357,13 +364,13 @@ importers:
 
   packages/refs-react:
     dependencies:
+      '@automerge/automerge-repo':
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       react:
         specifier: ^18.0.0
         version: 18.3.1
     devDependencies:
-      '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.1
@@ -428,32 +435,32 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
+        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
+        version: link:../../../automerge-repo/packages/automerge-vanillajs
       '@codemirror/language':
         specifier: ^6.11.3
-        version: 6.12.3
+        version: 6.11.3
       '@codemirror/state':
         specifier: ^6.5.2
-        version: 6.6.0
+        version: 6.5.2
       '@codemirror/view':
         specifier: ^6.38.6
-        version: 6.41.1
+        version: 6.38.8
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../../core/elements
@@ -471,8 +478,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: link:../../../automerge-repo-keyhive
+        version: link:../../../automerge-repo-keyhive
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -513,32 +520,32 @@ importers:
         specifier: 3.2.6
         version: 3.2.6
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo
+        version: link:../../../automerge-repo/packages/automerge-repo
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
+        version: link:../../../automerge-repo/packages/automerge-repo-network-messagechannel
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: link:../../../automerge-repo/packages/automerge-repo-react-hooks
+        version: link:../../../automerge-repo/packages/automerge-repo-react-hooks
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
+        version: link:../../../automerge-repo/packages/automerge-repo-storage-indexeddb
       '@automerge/automerge-subduction':
         specifier: 0.12.1
         version: 0.12.1
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.20
-        version: 2.6.0-subduction.20
+        specifier: link:../../../automerge-repo/packages/automerge-vanillajs
+        version: link:../../../automerge-repo/packages/automerge-vanillajs
       '@codemirror/language':
         specifier: ^6.11.3
-        version: 6.12.3
+        version: 6.11.3
       '@codemirror/state':
         specifier: ^6.5.2
-        version: 6.6.0
+        version: 6.5.2
       '@codemirror/view':
         specifier: ^6.38.6
-        version: 6.41.1
+        version: 6.38.8
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../../core/elements
@@ -550,14 +557,14 @@ importers:
         version: link:../../core/plugins
       solid-js:
         specifier: ^1.9.9
-        version: 1.9.10
+        version: 1.9.9
       tailwindcss:
         specifier: ^4.1.14
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: link:../../../automerge-repo-keyhive
+        version: link:../../../automerge-repo-keyhive
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -597,35 +604,11 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@automerge/automerge-repo-keyhive@0.2.0-alpha.1d':
-    resolution: {integrity: sha512-p+4PnUua9vtvmdoZQXNOdl6SJGISF90JHi95zw33gUen4LHerNgXx7RVc0uDMC6WOfhKxJANqE2f+VKCQwis9w==}
-
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.20':
-    resolution: {integrity: sha512-L9fOFGaCG5ry4L7Ya223QaRAd16w743N4U23f4mOKzhC7M3FFXqseHqnhYIyjF1g6xs7y0JHghfV2C54cvY+uw==}
-
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.20':
-    resolution: {integrity: sha512-1cwnTLvidyFS6Vch4VntnmtvFPs8phvKJvd2lIhtX8rDdTyfoGkzHcpeIcuTOzuyGXn78bFUJsAOhw4fXuW+Kw==}
-
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.20':
-    resolution: {integrity: sha512-N05WTZfosGYLrljt+qdtWbreqqWuvHQSf/2qAhGmkolfUBCz5BlnTtZ4hwhpXW1RICEOzrC9o+d4gYNN+Og3fw==}
-
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.20':
-    resolution: {integrity: sha512-eX0n1uW6Of/RD7k5H6MsvbLP79l6xhaE7qdKdk2LbnYkr0CqnKOxeTOQUFOVKMyvQw330OPGm1NeD604RJ91EA==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
   '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.20':
     resolution: {integrity: sha512-NQsgpqLb4fVfvzUMAZ2m5mvi657d4OOxdiXTxkeNmV49ll1BWmxfBmfGSBrLJHleldDH0Ev0GcXsq8KvVNf36Q==}
     peerDependencies:
       '@automerge/automerge': 3.2.6
       solid-js: ^1.9.4
-
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.20':
-    resolution: {integrity: sha512-AIbsvWw0oFKUkJChcDKgGsFWC45GzUfwp3OhmaKCUHeWZ9P7O/Lrv/IToljSSYkO6d4Nj+TmTyje1NJh3w88tw==}
-
-  '@automerge/automerge-repo@2.6.0-subduction.20':
-    resolution: {integrity: sha512-3LkXIFvY79bRSEtVMncUFjOp2KBIUN9C/j9FUsmlEBFSiK2Ec9E4qo2WWpg5aJ5rDXh/HzZe+ZSKDSAJwA77oA==}
 
   '@automerge/automerge-subduction@0.12.1':
     resolution: {integrity: sha512-s1s40RTozkqExIk1LYdogKPzpCMFfe/7KBS0ccAlwsy4JwdcUGG9NQO2Pm3kZq8vD3OPw7DcIOSPG+bnLESQFg==}
@@ -633,42 +616,12 @@ packages:
   '@automerge/automerge@3.2.6':
     resolution: {integrity: sha512-9/GXXfYYWNVGpnbRrGQzTNU4fWZ3XaEMeEg0OrpK4pvlQSpkmUBoirEb/4TMK6BwMysZGV5Yeneq3wwc7RNGfg==}
 
-  '@automerge/vanillajs@2.6.0-subduction.20':
-    resolution: {integrity: sha512-oZZa8AKAgjphiVw1NUPBtqUO2gCHR+FUhr4usbIA46WuxsbZFauLHyZsAyHowzKDS0FUB1DY6ZvGk45WKRWh+A==}
+  '@automerge/subduction@0.11.0':
+    resolution: {integrity: sha512-32GzWTuOA6htRXKA/KYZ33y9TZUazXjr9oQxuNZZwtkGoKnT1Vr1URLoEZj8LVX3oIwCZH6ZjkAXteUqDTG/+Q==}
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
-
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
-    resolution: {integrity: sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
-    resolution: {integrity: sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
-    resolution: {integrity: sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
-    resolution: {integrity: sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==}
-    cpu: [arm]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
-    resolution: {integrity: sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
-    resolution: {integrity: sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==}
-    cpu: [x64]
-    os: [win32]
 
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
@@ -725,14 +678,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@codemirror/language@6.12.3':
-    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+  '@codemirror/language@6.11.3':
+    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
 
-  '@codemirror/state@6.6.0':
-    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+  '@codemirror/state@6.5.2':
+    resolution: {integrity: sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==}
 
-  '@codemirror/view@6.41.1':
-    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+  '@codemirror/view@6.38.8':
+    resolution: {integrity: sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1444,14 +1397,14 @@ packages:
   '@keyhive/keyhive@0.0.0-alpha.56':
     resolution: {integrity: sha512-hx/MRkRqCSJFIh5jHKs9HkzDQy4tUZzgaRlc85+8t22VciubmZAU1FyugmYboskPUxUGwqZC1GarwXfxhrp5DA==}
 
-  '@lezer/common@1.5.2':
-    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+  '@lezer/common@1.3.0':
+    resolution: {integrity: sha512-L9X8uHCYU310o99L3/MpJKYxPzXPOS7S0NmBaM7UO/x2Kb2WbmMLSkfvdr1KxRIFYOpbY0Jhn7CfLSUDzL8arQ==}
 
-  '@lezer/highlight@1.2.3':
-    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+  '@lezer/highlight@1.2.2':
+    resolution: {integrity: sha512-z8TQwaBXXQIvG6i2g3e9cgMwUUXu9Ib7jo2qRRggdhwKpM56Dw3PM3wmexn+EGaaOZ7az0K7sjc3/gcGW7sz7A==}
 
-  '@lezer/lr@1.4.10':
-    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+  '@lezer/lr@1.4.2':
+    resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1461,10 +1414,6 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
-
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1912,9 +1861,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base-x@4.0.1:
-    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
-
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1929,12 +1875,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  bs58@5.0.0:
-    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
-
-  bs58check@3.0.1:
-    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
-
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1945,13 +1885,6 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
-
-  cbor-extract@2.2.0:
-    resolution: {integrity: sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==}
-    hasBin: true
-
-  cbor-x@1.6.0:
-    resolution: {integrity: sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -2186,9 +2119,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-sha256@1.3.0:
-    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
-
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2350,11 +2280,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-ws@5.0.0:
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '*'
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2611,10 +2536,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-gyp-build-optional-packages@5.1.1:
-    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
-    hasBin: true
-
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
@@ -2736,11 +2657,6 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
-
-  react-usestateref@1.0.9:
-    resolution: {integrity: sha512-t8KLsI7oje0HzfzGhxFXzuwbf1z9vhBM1ptHLUIHhYqZDKFuI5tzdhEVxSNzUkYxwF8XdpOErzHlKxvP7sTERw==}
-    peerDependencies:
-      react: '>16.0.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -3022,11 +2938,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -3320,9 +3231,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xstate@5.31.0:
-    resolution: {integrity: sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3349,128 +3257,18 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@automerge/automerge-repo-keyhive@0.2.0-alpha.1d':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.20
-      '@keyhive/keyhive': 0.0.0-alpha.56
-      cbor-x: 1.6.0
-      eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-      debug: 4.4.3
-      eventemitter3: 5.0.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-      cbor-x: 1.6.0
-      debug: 4.4.3
-      eventemitter3: 5.0.1
-      isomorphic-ws: 5.0.0(ws@8.18.3)
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@automerge/automerge': 3.2.6
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-      eventemitter3: 5.0.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-usestateref: 1.0.9(react@18.3.1)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.20(@automerge/automerge@3.2.6)(solid-js@1.9.9)':
     dependencies:
       '@automerge/automerge': 3.2.6
       solid-js: 1.9.9
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@automerge/automerge-repo@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge': 3.2.6
-      '@automerge/automerge-subduction': 0.12.1
-      bs58check: 3.0.1
-      cbor-x: 1.6.0
-      debug: 4.4.3
-      eventemitter3: 5.0.1
-      fast-sha256: 1.3.0
-      isomorphic-ws: 5.0.0(ws@8.18.3)
-      uuid: 9.0.1
-      ws: 8.18.3
-      xstate: 5.31.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@automerge/automerge-subduction@0.12.1': {}
 
   '@automerge/automerge@3.2.6': {}
 
-  '@automerge/vanillajs@2.6.0-subduction.20':
-    dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.20
-      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.20
-      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.20
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.20
-      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.20
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
+  '@automerge/subduction@0.11.0': {}
 
   '@babel/runtime@7.28.4': {}
-
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
-    optional: true
-
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
-    optional: true
-
-  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
-    optional: true
-
-  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
-    optional: true
 
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
@@ -3616,22 +3414,22 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@codemirror/language@6.12.3':
+  '@codemirror/language@6.11.3':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.41.1
-      '@lezer/common': 1.5.2
-      '@lezer/highlight': 1.2.3
-      '@lezer/lr': 1.4.10
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.8
+      '@lezer/common': 1.3.0
+      '@lezer/highlight': 1.2.2
+      '@lezer/lr': 1.4.2
       style-mod: 4.1.3
 
-  '@codemirror/state@6.6.0':
+  '@codemirror/state@6.5.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.41.1':
+  '@codemirror/view@6.38.8':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.5.2
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -4046,15 +3844,15 @@ snapshots:
 
   '@keyhive/keyhive@0.0.0-alpha.56': {}
 
-  '@lezer/common@1.5.2': {}
+  '@lezer/common@1.3.0': {}
 
-  '@lezer/highlight@1.2.3':
+  '@lezer/highlight@1.2.2':
     dependencies:
-      '@lezer/common': 1.5.2
+      '@lezer/common': 1.3.0
 
-  '@lezer/lr@1.4.10':
+  '@lezer/lr@1.4.2':
     dependencies:
-      '@lezer/common': 1.5.2
+      '@lezer/common': 1.3.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4073,8 +3871,6 @@ snapshots:
       read-yaml-file: 1.1.0
 
   '@marijn/find-cluster-break@1.0.2': {}
-
-  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4507,8 +4303,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base-x@4.0.1: {}
-
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -4526,37 +4320,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  bs58@5.0.0:
-    dependencies:
-      base-x: 4.0.1
-
-  bs58check@3.0.1:
-    dependencies:
-      '@noble/hashes': 1.8.0
-      bs58: 5.0.0
-
   buffer-from@1.1.2:
     optional: true
 
   cac@6.7.14: {}
 
   callsites@3.1.0: {}
-
-  cbor-extract@2.2.0:
-    dependencies:
-      node-gyp-build-optional-packages: 5.1.1
-    optionalDependencies:
-      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.0
-      '@cbor-extract/cbor-extract-darwin-x64': 2.2.0
-      '@cbor-extract/cbor-extract-linux-arm': 2.2.0
-      '@cbor-extract/cbor-extract-linux-arm64': 2.2.0
-      '@cbor-extract/cbor-extract-linux-x64': 2.2.0
-      '@cbor-extract/cbor-extract-win32-x64': 2.2.0
-    optional: true
-
-  cbor-x@1.6.0:
-    optionalDependencies:
-      cbor-extract: 2.2.0
 
   chai@5.3.3:
     dependencies:
@@ -4884,8 +4653,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-sha256@1.3.0: {}
-
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5038,10 +4805,6 @@ snapshots:
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-ws@5.0.0(ws@8.18.3):
-    dependencies:
-      ws: 8.18.3
 
   jiti@2.6.1: {}
 
@@ -5252,11 +5015,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-gyp-build-optional-packages@5.1.1:
-    dependencies:
-      detect-libc: 2.1.2
-    optional: true
-
   nwsapi@2.2.22: {}
 
   optionator@0.9.4:
@@ -5355,10 +5113,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-usestateref@1.0.9(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   react@18.3.1:
     dependencies:
@@ -5615,8 +5369,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  uuid@9.0.1: {}
 
   vite-node@2.1.9(@types/node@24.9.1)(lightningcss@1.32.0)(terser@5.44.0):
     dependencies:
@@ -5936,8 +5688,6 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xstate@5.31.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ packages:
 catalog:
   "@automerge/automerge": 3.2.6
   "@automerge/automerge-repo": 2.6.0-subduction.22
-  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.3
+  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.4
   "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.22
   "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.22
   "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.22

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,17 +8,17 @@ packages:
 
 catalog:
   "@automerge/automerge": 3.2.6
-  "@automerge/automerge-repo": 2.6.0-subduction.21
-  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.1
-  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.21
-  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.21
-  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.21
-  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.21
-  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.21
+  "@automerge/automerge-repo": 2.6.0-subduction.22
+  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.3
+  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.22
+  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.22
+  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.22
+  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.22
+  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.22
   "@automerge/automerge-subduction": 0.13.0
-  "@automerge/react": 2.6.0-subduction.21
-  "@automerge/vanillajs": 2.6.0-subduction.21
-  "@keyhive/keyhive": 0.0.0-alpha.56
+  "@automerge/react": 2.6.0-subduction.22
+  "@automerge/vanillajs": 2.6.0-subduction.22
+  "@keyhive/keyhive": 0.0.0-alpha.58b
   "@types/react": 18.3.1
   "@types/react-dom": 18.3.1
   react: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,16 +8,16 @@ packages:
 
 catalog:
   "@automerge/automerge": 3.2.6
-  "@automerge/automerge-repo": 2.6.0-subduction.20
-  "@automerge/automerge-repo-keyhive": 0.2.0-alpha.1d
-  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.20
-  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.20
-  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.20
-  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.20
-  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.20
-  "@automerge/automerge-subduction": 0.12.1
-  "@automerge/react": 2.6.0-subduction.20
-  "@automerge/vanillajs": 2.6.0-subduction.20
+  "@automerge/automerge-repo": 2.6.0-subduction.21
+  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.1
+  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.21
+  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.21
+  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.21
+  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.21
+  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.21
+  "@automerge/automerge-subduction": 0.13.0
+  "@automerge/react": 2.6.0-subduction.21
+  "@automerge/vanillajs": 2.6.0-subduction.21
   "@keyhive/keyhive": 0.0.0-alpha.56
   "@types/react": 18.3.1
   "@types/react-dom": 18.3.1

--- a/sites/gaios/src/main.ts
+++ b/sites/gaios/src/main.ts
@@ -1,7 +1,7 @@
 import "./global.css";
 
-import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
 // Published tools are registered in this module-settings doc via
 // `pnpm register` from each tool's own repo (see patchwork-tools and
@@ -14,4 +14,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "gaiosAccountUrl",
   titleSuffix: "GAIOS",
+  keyhive: true,
 });

--- a/sites/gaios/src/main.ts
+++ b/sites/gaios/src/main.ts
@@ -1,5 +1,7 @@
 import "./global.css";
 
+declare const __KEYHIVE__: boolean;
+
 import type { AutomergeUrl } from "@automerge/automerge-repo";
 import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
@@ -14,5 +16,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "gaiosAccountUrl",
   titleSuffix: "GAIOS",
-  keyhive: true,
+  keyhive: __KEYHIVE__,
 });

--- a/sites/gaios/vite.config.ts
+++ b/sites/gaios/vite.config.ts
@@ -22,6 +22,7 @@ const subductionDir = dirname(
 export default defineConfig({
   define: {
     __SITE_NAME__: JSON.stringify("gaios"),
+    __KEYHIVE__: JSON.stringify(process.env.KEYHIVE === "true"),
   },
   plugins: [
     tailwindcss(),

--- a/sites/gaios/vite.config.ts
+++ b/sites/gaios/vite.config.ts
@@ -20,6 +20,9 @@ const subductionDir = dirname(
 );
 
 export default defineConfig({
+  define: {
+    __SITE_NAME__: JSON.stringify("gaios"),
+  },
   plugins: [
     tailwindcss(),
     wasm(),
@@ -29,6 +32,7 @@ export default defineConfig({
           DEV: "data:text/javascript,export%20const%20DEV%20=%20true;",
         },
       },
+      extraBuiltins: ["@automerge/automerge-repo-keyhive"],
     }),
   ],
   worker: {
@@ -63,6 +67,7 @@ export default defineConfig({
     exclude: [
       "@automerge/automerge-subduction",
       "@automerge/automerge-subduction/slim",
+      "@automerge/automerge-repo-keyhive",
     ],
   },
   build: {

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -1,7 +1,7 @@
 import "./global.css";
 
-import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
 // Published tools are registered in this module-settings doc via
 // `pnpm register` from each tool's own repo (see patchwork-tools and
@@ -14,4 +14,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "tinyPatchworkAccountUrl",
   titleSuffix: "patchwork",
+  keyhive: true,
 });

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -1,5 +1,7 @@
 import "./global.css";
 
+declare const __KEYHIVE__: boolean;
+
 import type { AutomergeUrl } from "@automerge/automerge-repo";
 import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
@@ -14,5 +16,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "tinyPatchworkAccountUrl",
   titleSuffix: "patchwork",
-  keyhive: true,
+  keyhive: __KEYHIVE__,
 });

--- a/sites/tiny-patchwork/vite.config.ts
+++ b/sites/tiny-patchwork/vite.config.ts
@@ -22,6 +22,7 @@ const subductionDir = dirname(
 export default defineConfig({
   define: {
     __SITE_NAME__: JSON.stringify("tiny-patchwork"),
+    __KEYHIVE__: JSON.stringify(process.env.KEYHIVE === "true"),
   },
   plugins: [
     tailwindcss(),

--- a/sites/tiny-patchwork/vite.config.ts
+++ b/sites/tiny-patchwork/vite.config.ts
@@ -20,6 +20,9 @@ const subductionDir = dirname(
 );
 
 export default defineConfig({
+  define: {
+    __SITE_NAME__: JSON.stringify("tiny-patchwork"),
+  },
   plugins: [
     tailwindcss(),
     wasm(),
@@ -28,6 +31,10 @@ export default defineConfig({
         imports: {
           DEV: "data:text/javascript,export%20const%20DEV%20=%20true;",
         },
+      },
+      extraBuiltins: {
+        "@automerge/automerge-repo-keyhive":
+          "/packages/@automerge/automerge-repo-keyhive/index.js",
       },
     }),
   ],
@@ -63,6 +70,7 @@ export default defineConfig({
     exclude: [
       "@automerge/automerge-subduction",
       "@automerge/automerge-subduction/slim",
+      "@automerge/automerge-repo-keyhive",
     ],
   },
   build: {


### PR DESCRIPTION
The real keyhive integration PR is #277.

This is now being used to deploy the keyhive subduction version of TPW to bee.patchwork. Once we're done testing on there, I'll close this PR.