### PR TITLE
fix: clear errors when tool renders after delayed load

### DIFF
--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -261,6 +261,9 @@ export function registerPatchworkViewElement(
           return;
         }
 
+        // Clear any previous content and error styles
+        this.#resetDisplay();
+
         this.#fallbackId = getFallbackTool(this.#handle.doc())?.id;
         const fallingBack = !this.toolId;
 
@@ -327,6 +330,13 @@ export function registerPatchworkViewElement(
             `,
           })
         );
+      };
+
+      #resetDisplay = () => {
+        this.replaceChildren();
+        this.style.display = "";
+        this.style.alignItems = "";
+        this.style.justifyContent = "";
       };
     }
   );


### PR DESCRIPTION
This clears the "failed to load" error when a tool that had to be loaded async successfully loads and is rendered.