### PR TITLE
Add build step to README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ This repository holds the Patchwork System, and the famous Tiny Patchwork frame.
 git clone https://github.com/inkandswitch/patchwork-next
 cd patchwork-next
 pnpm install
+pnpm build
 SITE=tiny-patchwork pnpm dev
 ```


### PR DESCRIPTION
I had to run `pnpm build` before `pnpm dev` would work 🤷‍♀️ Figured I'd add a line about that for anyone else that wanders into the project