### PR TITLE
Fix loading suggested modules

### DIFF
--- a/core/elements/src/events.ts
+++ b/core/elements/src/events.ts
@@ -17,12 +17,29 @@ export class OpenDocumentEvent extends CustomEvent<OpenDocumentEventDetail> {
   }
 }
 
+export interface MountedEventDetail {
+  url: AutomergeUrl;
+  toolId: string;
+}
+
+export class MountedEvent extends CustomEvent<MountedEventDetail> {
+  constructor(detail: MountedEventDetail) {
+    super("patchwork:mounted", {
+      detail,
+      composed: true,
+      bubbles: true,
+    });
+  }
+}
+
 declare global {
   interface ShadowRootEventMap extends ElementEventMap {
     "patchwork:open-document": OpenDocumentEvent;
+    "patchwork:mounted": MountedEvent;
   }
   interface ElementEventMap {
     "patchwork:open-document": OpenDocumentEvent;
+    "patchwork:mounted": MountedEvent;
   }
 }
 

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -224,8 +224,8 @@ export function registerPatchworkViewElement(
           }
         );
 
-
-        await this.moduleWatcher.loadSuggestedImportUrl(this.docUrl);        
+        // load the suggested import url for the document in the background
+        this.moduleWatcher.loadSuggestedImportUrl(this.docUrl)
 
         this.#teardowns.add(() => {
           removeAddedListener();

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -64,7 +64,7 @@ export function registerPatchworkViewElement(
   }
 
   const attrs = {
-      docUrl: "doc-url",
+    docUrl: "doc-url",
     toolId: "tool-id",
   };
 
@@ -129,7 +129,7 @@ export function registerPatchworkViewElement(
 
       // When defined, this is called instead of connectedCallback() and disconnectedCallback()
       // each time the element is moved to a different place in the DOM via Element.moveBefore()
-      connectedMoveCallback() {}
+      connectedMoveCallback() { }
 
       attributeChangedCallback(name: string, _: string, val: string | null) {
         if (name === attrs.toolId) {
@@ -150,8 +150,8 @@ export function registerPatchworkViewElement(
       ) => {
         const { before, after } = payload.patchInfo;
 
-        if (getSuggestedImportUrl(before) != getSuggestedImportUrl(after)) {
-          this.#teardown().then(() => this.#init());
+        if (this.docUrl && getSuggestedImportUrl(before) != getSuggestedImportUrl(after)) {
+          this.moduleWatcher.loadSuggestedImportUrl(this.docUrl);
         }
 
         if (getType(before) != getType(after)) {
@@ -172,10 +172,6 @@ export function registerPatchworkViewElement(
         this.#state = State.initializing;
 
         this.#handle = await repo.find<HasPatchworkMetadata>(this.docUrl!);
-
-        if (!this.#handle) {
-          debugger
-        }
 
         // TODO: these are inlined and not separate functions
         // because we need to do some work getting types working well here.

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -16,6 +16,7 @@ import {
   isLoadablePlugin,
   type LoadedTool,
 } from "@inkandswitch/patchwork-plugins";
+import { MountedEvent } from "./events.js";
 
 import type { initializeAutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 
@@ -63,7 +64,7 @@ export function registerPatchworkViewElement(
   }
 
   const attrs = {
-    docUrl: "doc-url",
+      docUrl: "doc-url",
     toolId: "tool-id",
   };
 
@@ -325,6 +326,7 @@ export function registerPatchworkViewElement(
           }
           this.#teardowns.add(cleanup);
           this.#state = fallingBack ? "fallback" : "rendered";
+          this.dispatchEvent(new MountedEvent({ url: this.docUrl, toolId }));
         } catch (error) {
           this.append(
             Object.assign(document.createElement("div"), {

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -8,6 +8,7 @@ import {
   getSuggestedImportUrl,
   getType,
   type HasPatchworkMetadata,
+  type ModuleWatcher,
 } from "@inkandswitch/patchwork-filesystem";
 import {
   getFallbackTool,
@@ -38,11 +39,13 @@ export interface RegisterPatchworkViewElementParams {
   name?: string;
   repo: Repo;
   hive?: AutomergeRepoKeyhive;
+  moduleWatcher: ModuleWatcher;
 }
 
 export interface PatchworkViewElement extends HTMLElement {
   repo: Repo;
   hive?: AutomergeRepoKeyhive;
+  moduleWatcher: ModuleWatcher;
   docUrl?: AutomergeUrl;
   toolId?: string;
 }
@@ -69,6 +72,7 @@ export function registerPatchworkViewElement(
     class PatchworkViewElement extends HTMLElement {
       repo = repo;
       hive = params.hive;
+      moduleWatcher = params.moduleWatcher;
       // attributes, if these change it's new game +
       #docUrl: AutomergeUrl | null = null;
       #toolId: string | null = null;
@@ -168,6 +172,10 @@ export function registerPatchworkViewElement(
 
         this.#handle = await repo.find<HasPatchworkMetadata>(this.docUrl!);
 
+        if (!this.#handle) {
+          debugger
+        }
+
         // TODO: these are inlined and not separate functions
         // because we need to do some work getting types working well here.
         // @chee would be good to chat about this at some point.
@@ -215,6 +223,9 @@ export function registerPatchworkViewElement(
             }
           }
         );
+
+
+        await this.moduleWatcher.loadSuggestedImportUrl(this.docUrl);        
 
         this.#teardowns.add(() => {
           removeAddedListener();

--- a/sites/gaios/src/main.ts
+++ b/sites/gaios/src/main.ts
@@ -158,10 +158,15 @@ rootElement.addEventListener("patchwork:open-document", (event) => {
   window.location.hash = params.toString();
 });
 
+rootElement.addEventListener("patchwork:mounted", () => {
+  handleHashChange();
+});
+
 const bigPatchworkHashRegex =
   /(?<title>[A-Za-z0-9-]+)--(?<docId>[1-9A-HJ-NP-Za-km-z]+)(?<type>\?=[^&?]+)?/;
 
-const handleHashChange = async (hash: string) => {
+const handleHashChange = async () => {
+  const hash = window.location.hash.slice(1);
   const legacy = bigPatchworkHashRegex.exec(hash);
 
   if (legacy) {
@@ -193,14 +198,5 @@ const handleHashChange = async (hash: string) => {
 
 // Listen for hash changes and interpret them as Automerge URLs
 window.addEventListener("hashchange", () => {
-  const hash = window.location.hash;
-  handleHashChange(hash.slice(1));
+  handleHashChange();
 });
-
-if (window.location.hash) {
-  const hash = window.location.hash.slice(1);
-  // todo: actually wait for root to be mounted
-  setTimeout(() => {
-    handleHashChange(hash);
-  }, 100);
-}

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -169,10 +169,18 @@ rootElement.addEventListener("patchwork:open-document", (event) => {
   window.location.hash = params.toString();
 });
 
+rootElement.addEventListener(
+  "patchwork:mounted",
+  () => {
+      handleHashChange();
+  }
+);
+
 const bigPatchworkHashRegex =
   /(?<title>[A-Za-z0-9-]+)--(?<docId>[1-9A-HJ-NP-Za-km-z]+)(?<type>\?=[^&?]+)?/;
 
-const handleHashChange = async (hash: string) => {
+const handleHashChange = async () => {
+  const hash = window.location.hash.slice(1);
   const legacy = bigPatchworkHashRegex.exec(hash);
 
   if (legacy) {
@@ -204,14 +212,9 @@ const handleHashChange = async (hash: string) => {
 
 // Listen for hash changes and interpret them as Automerge URLs
 window.addEventListener("hashchange", () => {
-  const hash = window.location.hash;
-  handleHashChange(hash.slice(1));
+
+
+    handleHashChange();
+  
 });
 
-if (window.location.hash) {
-  const hash = window.location.hash.slice(1);
-  // todo: actually wait for root to be mounted
-  setTimeout(() => {
-    handleHashChange(hash);
-  }, 100);
-}

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -126,7 +126,7 @@ const accountDocHandle = await getOrCreateLayoutDocHandle(repo);
 
 window.accountDocHandle = accountDocHandle;
 
-const _moduleWatcher = new ModuleWatcher(
+const moduleWatcher = new ModuleWatcher(
   repo,
   [
 
@@ -144,7 +144,7 @@ const _moduleWatcher = new ModuleWatcher(
   }
 );
 
-registerPatchworkViewElement({ repo });
+registerPatchworkViewElement({ moduleWatcher, repo });
 
 const rootElement = document.getElementById("root")!;
 

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -172,7 +172,7 @@ rootElement.addEventListener("patchwork:open-document", (event) => {
 rootElement.addEventListener(
   "patchwork:mounted",
   () => {
-      handleHashChange();
+    handleHashChange();
   }
 );
 
@@ -212,9 +212,6 @@ const handleHashChange = async () => {
 
 // Listen for hash changes and interpret them as Automerge URLs
 window.addEventListener("hashchange", () => {
-
-
-    handleHashChange();
-  
+  handleHashChange();
 });
 


### PR DESCRIPTION
This PR fixes document loading when the user doesn't have the tool installed.

**Changes:**
- Pass module watcher to `registerPatchworkView` so we can call `loadSuggestedModuleUrl`
- `patchwork-view` now emits a `patchwork:mounted` event when a new tool mounts — this lets us reliably send `patchwork:open-document` for the URL on initial page load (previously this was a bit flaky)