### PR TITLE
Disable loading suggested import URL automatically

### DIFF
--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -150,9 +150,9 @@ export function registerPatchworkViewElement(
       ) => {
         const { before, after } = payload.patchInfo;
 
-        if (this.docUrl && getSuggestedImportUrl(before) != getSuggestedImportUrl(after)) {
-          this.moduleWatcher.loadSuggestedImportUrl(this.docUrl);
-        }
+        //if (this.docUrl && getSuggestedImportUrl(before) != getSuggestedImportUrl(after)) {
+        //  this.moduleWatcher.loadSuggestedImportUrl(this.docUrl);
+        //}
 
         if (getType(before) != getType(after)) {
           this.#teardown().then(() => this.#init());
@@ -222,7 +222,7 @@ export function registerPatchworkViewElement(
         );
 
         // load the suggested import url for the document in the background
-        this.moduleWatcher.loadSuggestedImportUrl(this.docUrl)
+        // this.moduleWatcher.loadSuggestedImportUrl(this.docUrl)
 
         this.#teardowns.add(() => {
           removeAddedListener();


### PR DESCRIPTION
This loads the suggested import url unconditionally, which is a problem if you already have a loaded package for this with the same `id` that is the one you want and are currently working on.

is there a way we can do it conditionally? or prompt the user to load the suggested import url with a button!!!

