### PR TITLE
keep all registered versions of a plugin around so it can be inspected

### DIFF
--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -24,13 +24,18 @@ function isAsyncFunction(fn: unknown) {
   );
 }
 
+export type PluginEntry<D extends PluginDescription, I> = {
+  importUrl: string;
+  plugin: Plugin<D, I>;
+};
+
 /**
  * Registry for managing plugins of a specific type
  * D = Description type that extends PluginDescription
  * I = Implementation type that will be loaded and combined with the description
  */
 export class PluginRegistry<D extends PluginDescription, I = any> {
-  #plugins = new Map<string, Plugin<D, I>>();
+  #plugins = new Map<string, PluginEntry<D, I>[]>();
   #loadPromises = new Map<string, Promise<LoadedPlugin<D, I>>>();
   #events = new EventEmitter<PluginRegistryEvents<D, I>>();
 
@@ -43,16 +48,24 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
       plugin.importUrl = importUrl;
     }
 
-    const existing = this.#plugins.get(plugin.id);
+    let entries = this.#plugins.get(plugin.id);
 
-    if (existing) {
-      console.warn(
-        `overriding "${plugin.id}" provided by "${existing.importUrl}" with new plugin provided by "${importUrl}"`
-      );
+    if (entries?.[0]) {
+      const old = entries[0].importUrl;
+      if (old === importUrl) {
+        log(`Updating existing plugin: ${plugin.id} from ${importUrl}`);
+      } else {
+        console.warn(
+          `overriding "${plugin.id}" provided by "${entries[0].importUrl}" with new plugin provided by "${importUrl}"`
+        );
+      }
     }
 
-    this.#plugins.set(plugin.id, plugin);
+    if (!entries) entries = [];
 
+    entries.unshift({ importUrl: importUrl, plugin });
+
+    this.#plugins.set(plugin.id, entries);
     this.#events.emit("registered", plugin);
     this.#events.emit("changed");
   }
@@ -61,12 +74,19 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
    * Get an plugin by ID, returning either its description or loaded state
    */
   get(id: string): Plugin<D, I> | undefined {
-    return this.#plugins.get(id);
+    return this.#plugins.get(id)?.at(0)?.plugin;
+  }
+
+  entries(id: string): PluginEntry<D, I>[] {
+    const list = this.#plugins.get(id);
+    return list ?? [];
   }
 
   /** Get all plugins, both descriptions and loaded */
   all(): Plugin<D, I>[] {
-    const entries = Array.from(this.#plugins.values());
+    const entries = Array.from(
+      this.#plugins.values().map((entries) => entries[0].plugin)
+    );
     return entries as Plugin<D, I>[];
   }
 

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -77,6 +77,11 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
     return this.#plugins.get(id)?.at(0)?.plugin;
   }
 
+  entry(id: string): PluginEntry<D, I> | undefined {
+    const list = this.#plugins.get(id);
+    return list ? list[0] : undefined;
+  }
+
   entries(id: string): PluginEntry<D, I>[] {
     const list = this.#plugins.get(id);
     return list ?? [];
@@ -116,11 +121,13 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
     }
 
     // Get the plugin description
-    const description = this.#plugins.get(id);
+    const entry = this.entry(id);
+    const description = entry?.plugin;
     if (!description) {
       log(`Plugin not registered: ${id}`);
       return undefined;
     }
+    const identifier = `${id}@${entry.importUrl}`;
 
     // If the plugin is loadable, load it
     if (isLoadablePlugin(description)) {
@@ -161,8 +168,19 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
           }
 
           // Store the loaded version
-          this.#plugins.set(description.id, plugin);
-          this.#loadPromises.delete(id);
+          const entries = this.#plugins.get(description.id);
+          if (!entries) {
+            throw new Error("Plugin entries missing after load");
+          }
+          const existing = entries.find(
+            (e) => e.importUrl === description.importUrl
+          );
+          if (!existing) {
+            throw new Error("Plugin entry missing after load");
+          }
+          existing.plugin = plugin;
+          this.#plugins.set(description.id, entries);
+          this.#loadPromises.delete(identifier);
 
           // Notify listeners that an plugin has been loaded
           this.#events.emit("loaded", plugin);
@@ -172,12 +190,12 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
         })
         .catch((error) => {
           console.error(`Failed to load plugin implementation: ${id}`, error);
-          this.#loadPromises.delete(id);
+          this.#loadPromises.delete(identifier);
           throw error;
         });
 
       // Store the promise so we don't load twice
-      this.#loadPromises.set(id, loadPromise);
+      this.#loadPromises.set(identifier, loadPromise);
       return loadPromise;
     }
 
@@ -185,7 +203,7 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
       return description;
     }
 
-    throw new Error(`Plugin ${id} is not loadable`);
+    throw new Error(`Plugin ${identifier} is not loadable`);
   }
 
   /**


### PR DESCRIPTION
this pr shouldn't change anything about current behaviour, but if we keep other impls around maybe we can do something with them question mark