### PR TITLE
Add Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,128 @@
+{
+  "nodes": {
+    "command-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1769220798,
+        "narHash": "sha256-ulD8bbh5eV4rUH61JC4gS8Ik0R2hBEEyCom3f8w2vXE=",
+        "ref": "refs/heads/main",
+        "rev": "6c72a70e0241a5af26ba664ab63f3e2d89c45cd0",
+        "revCount": 5,
+        "type": "git",
+        "url": "https://codeberg.org/expede/nix-command-utils"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/expede/nix-command-utils"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769089682,
+        "narHash": "sha256-9yA/LIuAVQq0lXelrZPjLuLVuZdm03p8tfmHhnDIkms=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-25.11",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1769318308,
+        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "command-utils": "command-utils",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Patchwork Next: A malleable software environment for collaborative work";
+
+  inputs = {
+    command-utils.url = "git+https://codeberg.org/expede/nix-command-utils";
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+  };
+
+  outputs = {
+    self,
+    command-utils,
+    flake-utils,
+    nixpkgs,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+
+      nodejs = pkgs.nodejs_24;
+      pnpm-pkg = pkgs.pnpm;
+      pnpm' = "${pnpm-pkg}/bin/pnpm";
+
+      asModule = command-utils.asModule.${system};
+      cmd = command-utils.cmd.${system};
+      pnpm = command-utils.pnpm.${system};
+
+      pnpm-cfg = { pnpm = pnpm'; };
+
+      menu = command-utils.commands.${system} [
+        (pnpm.build pnpm-cfg)
+        (pnpm.dev pnpm-cfg)
+        (pnpm.install pnpm-cfg)
+        (pnpm.test pnpm-cfg)
+        (asModule {
+          "clean" = cmd "Remove node_modules and dist" "rm -rf **/node_modules **/dist";
+          "dev:tiny" = cmd "Start dev server (tiny-patchwork)" "${pnpm'} dev";
+          "dev:gaios" = cmd "Start dev server for Gaios" "SITE=gaios ${pnpm'} dev";
+          "dev:hive" = cmd "Start dev server for Hive" "SITE=hive ${pnpm'} dev";
+          "format" = cmd "Format code" "${pnpm'} format";
+          "format:check" = cmd "Check code formatting" "${pnpm'} format:check";
+          "make:tool" = cmd "Create a new tool" "${pnpm'} make-tool";
+          "preview" = cmd "Preview production build" "${pnpm'} preview";
+          "publish:packages" = cmd "Publish packages" "${pnpm'} publish-packages";
+          "tsc" = cmd "Run TypeScript compiler" "${pnpm'} tsc";
+        })
+      ];
+
+    in {
+      devShells.default = pkgs.mkShell {
+        name = "Patchwork Next Dev Shell";
+
+        nativeBuildInputs = [
+          nodejs
+          pkgs.eslint
+          pkgs.nodePackages.vscode-langservers-extracted
+          pkgs.prettierd
+          pkgs.typescript
+          pkgs.typescript-language-server
+          pnpm-pkg
+        ] ++ menu;
+
+        shellHook = ''
+          menu
+        '';
+      };
+
+      formatter = pkgs.alejandra;
+    });
+}


### PR DESCRIPTION
I got bitten by a Nodejs version mismatch, so figured it was time for me to add a flake (if I'm the only  one to use it that's fine but it does make things more reproducible across machines, which can he helpful for working in a team)

## Add Nix flake for reproducible dev environment

Adds a Nix flake providing a consistent development shell with all required tooling.

### Dev Shell

Enter with `nix develop`. Includes:
- Node.js 24
- pnpm
- TypeScript + language server
- ESLint, Prettier

### Commands

Uses [nix-command-utils](https://codeberg.org/expede/nix-command-utils) for a discoverable command menu (run `menu` to see all):

| Command | Description |
|---------|-------------|
| `pnpm:build` | Build all packages |
| `pnpm:dev` | Start dev server |
| `pnpm:install` | Install dependencies |
| `pnpm:test` | Run tests |
| `dev:tiny` | Start dev server (tiny-patchwork) |
| `dev:gaios` | Start dev server for Gaios |
| `dev:hive` | Start dev server for Hive |
| `format` | Format code |
| `format:check` | Check code formatting |
| `make:tool` | Create a new tool |
| `preview` | Preview production build |
| `publish:packages` | Publish packages |
| `tsc` | Run TypeScript compiler |
| `clean` | Remove node_modules and dist |

How to use:

<img width="499" height="279" alt="Screenshot 2026-01-28 at 15 29 30" src="https://github.com/user-attachments/assets/6224d891-f0e2-419d-a193-9c409667e1be" />
