### PR TITLE
feat: add account history datatype and recorder & viewer tools

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1892,6 +1892,55 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  tools/tiny-patchwork/account-history:
+    dependencies:
+      '@automerge/automerge-repo-solid-primitives':
+        specifier: 2.5.2
+        version: 2.5.2(@automerge/automerge@3.2.4)(solid-js@1.9.10)
+    devDependencies:
+      '@automerge/automerge':
+        specifier: 3.2.4
+        version: 3.2.4
+      '@automerge/automerge-repo':
+        specifier: 2.5.2
+        version: 2.5.2
+      '@babel/core':
+        specifier: 7.28.4
+        version: 7.28.4
+      '@babel/parser':
+        specifier: 7.28.4
+        version: 7.28.4
+      '@inkandswitch/patchwork-bootloader':
+        specifier: workspace:^
+        version: link:../../../core/bootloader
+      '@inkandswitch/patchwork-elements':
+        specifier: workspace:^
+        version: link:../../../core/elements
+      '@inkandswitch/patchwork-filesystem':
+        specifier: workspace:^
+        version: link:../../../core/filesystem
+      '@inkandswitch/patchwork-plugins':
+        specifier: workspace:^
+        version: link:../../../core/plugins
+      babel-preset-solid:
+        specifier: ^1.9.9
+        version: 1.9.9(@babel/core@7.28.4)(solid-js@1.9.10)
+      solid-js:
+        specifier: ^1.9.9
+        version: 1.9.10
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.1.9
+        version: 7.2.6(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@7.2.6(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0))
+      vite-plugin-solid:
+        specifier: ^2.11.10
+        version: 2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.10)(vite@7.2.6(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0))
+
   tools/tiny-patchwork/commands:
     dependencies:
       '@automerge/automerge-repo-react-hooks':

--- a/tools/tiny-patchwork/account-history/.gitignore
+++ b/tools/tiny-patchwork/account-history/.gitignore
@@ -1,0 +1,8 @@
+dist
+node_modules
+.pushwork
+
+
+
+
+

--- a/tools/tiny-patchwork/account-history/package.json
+++ b/tools/tiny-patchwork/account-history/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@tiny-patchwork/account-history",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "pushwork": {
+    "url": "automerge:C7F6yua1W3LX3Pp6jSnQx53Byv3"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch"
+  },
+  "dependencies": {
+    "@automerge/automerge-repo-solid-primitives": "2.5.2"
+  },
+  "devDependencies": {
+    "@automerge/automerge": "catalog:",
+    "@automerge/automerge-repo": "catalog:",
+    "@babel/core": "7.28.4",
+    "@babel/parser": "7.28.4",
+    "@inkandswitch/patchwork-bootloader": "workspace:^",
+    "@inkandswitch/patchwork-elements": "workspace:^",
+    "@inkandswitch/patchwork-filesystem": "workspace:^",
+    "@inkandswitch/patchwork-plugins": "workspace:^",
+    "babel-preset-solid": "^1.9.9",
+    "solid-js": "^1.9.9",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.9",
+    "vite-plugin-solid": "^2.11.10",
+    "vite-plugin-css-injected-by-js": "^3.5.2"
+  }
+}

--- a/tools/tiny-patchwork/account-history/src/HistoryRecorder.tsx
+++ b/tools/tiny-patchwork/account-history/src/HistoryRecorder.tsx
@@ -1,0 +1,272 @@
+import {
+  onMount,
+  onCleanup,
+  createMemo,
+  createEffect,
+  createSignal,
+} from "solid-js";
+import {
+  Repo,
+  type AutomergeUrl,
+  type DocHandle,
+} from "@automerge/automerge-repo";
+import { useDocHandle } from "@automerge/automerge-repo-solid-primitives";
+import { OpenDocumentEvent } from "@inkandswitch/patchwork-elements";
+import {
+  getType,
+  type HasPatchworkMetadata,
+} from "@inkandswitch/patchwork-filesystem";
+import {
+  getFallbackTool,
+  getRegistry,
+  type DatatypeDescription,
+  type DatatypeImplementation,
+} from "@inkandswitch/patchwork-plugins";
+import {
+  ACCOUNT_HISTORY_DATATYPE,
+  DEDUPLICATION_TIME_THRESHOLD,
+  VIEWER_TOOL_ID,
+} from "./constants.ts";
+import {
+  type PatchworkToolProps,
+  type AccountDoc,
+  type HistoryDoc,
+  type HistoryEntry,
+} from "./types.ts";
+
+declare global {
+  interface Window {
+    accountDocHandle?: DocHandle<AccountDoc>;
+  }
+}
+
+async function getOrCreateAccountHistoryDoc(
+  repo: Repo,
+  accountHandle: DocHandle<AccountDoc>
+): Promise<DocHandle<HistoryDoc>> {
+  const accountDoc = accountHandle.doc();
+  if (!accountDoc) {
+    throw new Error("Account document not available");
+  }
+
+  // Check if history document already exists
+  const existingUrl = accountDoc.accountHistoryUrl;
+
+  if (existingUrl) {
+    try {
+      const handle = await repo.find<HistoryDoc>(existingUrl);
+      await handle.whenReady();
+      return handle;
+    } catch (error) {
+      console.error("Error loading existing history document:", error);
+      // Fall through to create new one
+    }
+  }
+
+  // Create new history document
+  const historyHandle = await repo.create2<HistoryDoc>({
+    ["@patchwork"]: { type: ACCOUNT_HISTORY_DATATYPE },
+    title: "Account History",
+    entries: [],
+  });
+
+  // Update account document with reference to history document
+  accountHandle.change((doc) => {
+    doc.accountHistoryUrl = historyHandle.url;
+  });
+
+  return historyHandle;
+}
+
+export function HistoryRecorder(props: PatchworkToolProps<any>) {
+  const [isInitialized, setIsInitialized] = createSignal(false);
+
+  // Get account doc handle from window
+  const accountDocHandle = createMemo(() => {
+    return window.accountDocHandle;
+  });
+
+  // Get history URL from account doc
+  const historyUrl = createMemo<AutomergeUrl | undefined>(() => {
+    const handle = accountDocHandle();
+    if (!handle) return undefined;
+
+    const doc = handle.doc();
+    return doc?.accountHistoryUrl;
+  });
+
+  // Subscribe to history document handle reactively
+  const historyHandle = useDocHandle<HistoryDoc>(historyUrl, {
+    repo: props.repo,
+  });
+
+  // Initialize history document if needed
+  createEffect(async () => {
+    const accHandle = accountDocHandle();
+    const existingHistoryUrl = historyUrl();
+
+    if (accHandle && !existingHistoryUrl && !isInitialized()) {
+      try {
+        setIsInitialized(true);
+        await getOrCreateAccountHistoryDoc(props.repo, accHandle);
+      } catch (error) {
+        console.error("Error initializing history document:", error);
+        setIsInitialized(false);
+      }
+    }
+  });
+
+  onMount(() => {
+    const onDocumentOpened = async (event: Event) => {
+      const openEvent = event as OpenDocumentEvent;
+      const { url: rawUrl, toolId: rawToolId } = openEvent.detail;
+      const [docUrl, ...heads] = rawUrl.split("#");
+      const url = docUrl as AutomergeUrl;
+      let toolId = rawToolId;
+
+      // Get document to extract title and type
+      const docHandle = await props.repo.find(url);
+      await docHandle.whenReady();
+      const doc = docHandle.doc();
+
+      if (!doc) {
+        console.warn("HistoryRecorder: failed to load document");
+        return;
+      }
+
+      const datatype = getType(doc as Partial<HasPatchworkMetadata>);
+
+      if (!toolId) {
+        // if the tool id isn't defined, use the current fallback tool
+        if (!datatype) {
+          console.warn(
+            "HistoryRecorder: no tool found for document type; skipping history recording"
+          );
+          return;
+        }
+        const fallbackTool = getFallbackTool(doc as HasPatchworkMetadata);
+        if (!fallbackTool) {
+          console.warn(
+            "HistoryRecorder: no tool found for document type; skipping history recording"
+          );
+          return;
+        }
+        toolId = fallbackTool.id;
+      }
+
+      if (toolId === VIEWER_TOOL_ID) {
+        return; // Don't record when opening the history viewer itself
+      }
+
+      const currentHistoryHandle = historyHandle();
+      if (!currentHistoryHandle) {
+        console.warn("HistoryRecorder: history handle not ready yet");
+        return;
+      }
+      const historyDoc = currentHistoryHandle.doc();
+      if (!historyDoc) {
+        console.warn("HistoryRecorder: history document not ready yet");
+        return;
+      }
+
+      // Deduplication: check if this entry is a duplicate from rapid clicks
+      const lastEntry = historyDoc.entries[historyDoc.entries.length - 1];
+      if (
+        lastEntry &&
+        lastEntry.docUrl === url &&
+        lastEntry.toolId === toolId &&
+        Date.now() - lastEntry.timestamp < DEDUPLICATION_TIME_THRESHOLD
+      ) {
+        return; // Skip recording - duplicate from rapid clicking
+      }
+
+      // Extract title
+      let docTitle = "Untitled";
+      if (datatype) {
+        const registry = getRegistry<DatatypeDescription>("patchwork:datatype");
+        const loaded = registry.get(datatype);
+        if (loaded && "module" in loaded) {
+          const impl = loaded.module as DatatypeImplementation;
+          try {
+            docTitle = impl.getTitle(doc) || "Untitled";
+          } catch {
+            // getTitle may fail if the document shape doesn't match the datatype
+          }
+        }
+      }
+
+      // Get current heads, unless the URL specified a head
+      let entryHeads = heads;
+      if (entryHeads.length === 0) entryHeads = docHandle.heads();
+
+      // Create new entry
+      const newEntry: HistoryEntry = {
+        timestamp: Date.now(),
+        docUrl: url,
+        docTitle,
+        docType: datatype || "unknown",
+        toolId,
+        heads: entryHeads,
+      };
+
+      // Add entry to history
+      currentHistoryHandle.change((doc) => {
+        doc.entries.push(newEntry);
+      });
+    };
+
+    // Listen to patchwork:open-document events (should fire once per user action)
+    document.addEventListener(
+      "patchwork:open-document",
+      onDocumentOpened as EventListener,
+      { capture: true }
+    );
+
+    onCleanup(() => {
+      document.removeEventListener(
+        "patchwork:open-document",
+        onDocumentOpened as EventListener,
+        { capture: true }
+      );
+    });
+  });
+
+  const openHistory = () => {
+    const currentHistoryUrl = historyUrl();
+    if (!currentHistoryUrl) {
+      console.warn("HistoryRecorder: no history URL yet");
+      return;
+    }
+
+    // Dispatch open document event
+    props.element.dispatchEvent(
+      new OpenDocumentEvent({
+        url: currentHistoryUrl,
+        toolId: VIEWER_TOOL_ID,
+      })
+    );
+  };
+
+  return (
+    <button
+      onClick={openHistory}
+      class="account-history-toolbar-button"
+      title="Open account history"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    </button>
+  );
+}

--- a/tools/tiny-patchwork/account-history/src/HistoryViewer.tsx
+++ b/tools/tiny-patchwork/account-history/src/HistoryViewer.tsx
@@ -1,0 +1,414 @@
+import { createSignal, createMemo, createEffect, For, Show } from "solid-js";
+import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { makeDocumentProjection } from "@automerge/automerge-repo-solid-primitives";
+import { OpenDocumentEvent } from "@inkandswitch/patchwork-elements";
+import {
+  getRegistry,
+  type ToolDescription,
+} from "@inkandswitch/patchwork-plugins";
+import {
+  type PatchworkToolProps,
+  type HistoryDoc,
+  type HistoryEntry,
+} from "./types.ts";
+
+type GroupingMode = "date" | "document";
+type DocumentSortMode = "recent" | "visits";
+
+const dateGroupFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true,
+});
+
+const shortDateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+// Helper function to get tool metadata from registry
+function getToolMetadata(toolId: string): { name: string; icon?: string } {
+  const toolRegistry = getRegistry<ToolDescription>("patchwork:tool");
+  const tool = toolRegistry.get(toolId);
+
+  if (tool) {
+    return {
+      name: tool.name || toolId,
+      icon: tool.icon,
+    };
+  }
+
+  // Fallback if tool not found in registry
+  return {
+    name: toolId,
+    icon: "File",
+  };
+}
+
+function HistoryEntryRow(props: {
+  entry: HistoryEntry;
+  timeDisplay: string;
+  urlDisplay: string;
+  onOpen: (entry: HistoryEntry) => void;
+  onDelete: (e: MouseEvent, entry: HistoryEntry) => void;
+}) {
+  const toolMetadata = getToolMetadata(props.entry.toolId);
+
+  return (
+    <div class="account-history-entry">
+      <div class="account-history-entry-time">{props.timeDisplay}</div>
+      <div
+        class="account-history-entry-content"
+        onClick={() => props.onOpen(props.entry)}
+      >
+        <span class="account-history-entry-title">{props.entry.docTitle}</span>
+        <span class="account-history-entry-tool">— {toolMetadata.name}</span>
+        <span class="account-history-entry-url">{props.urlDisplay}</span>
+      </div>
+      <div class="account-history-entry-actions">
+        <button
+          class="account-history-entry-delete"
+          onClick={(e) => props.onDelete(e, props.entry)}
+          aria-label="Delete from history"
+          title="Delete from history"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function HistoryViewer(props: PatchworkToolProps<HistoryDoc>) {
+  const historyDoc = makeDocumentProjection<HistoryDoc>(props.handle);
+
+  // Load preferences from localStorage
+  const savedGroupingMode = (localStorage.getItem("history-grouping-mode") ||
+    "date") as GroupingMode;
+  const savedSortMode = (localStorage.getItem("history-document-sort-mode") ||
+    "recent") as DocumentSortMode;
+  const savedSearchQuery = localStorage.getItem("history-search-query") || "";
+
+  const [groupingMode, setGroupingMode] =
+    createSignal<GroupingMode>(savedGroupingMode);
+  const [documentSortMode, setDocumentSortMode] =
+    createSignal<DocumentSortMode>(savedSortMode);
+  const [searchQuery, setSearchQuery] = createSignal<string>(savedSearchQuery);
+  const [expandedGroups, setExpandedGroups] = createSignal<Set<AutomergeUrl>>(
+    new Set()
+  );
+
+  // Save preferences to localStorage when they change
+  createEffect(() => {
+    localStorage.setItem("history-grouping-mode", groupingMode());
+  });
+
+  createEffect(() => {
+    localStorage.setItem("history-document-sort-mode", documentSortMode());
+  });
+
+  createEffect(() => {
+    localStorage.setItem("history-search-query", searchQuery());
+  });
+
+  // Filter entries based on search query
+  const filteredEntries = createMemo(() => {
+    const query = searchQuery().toLowerCase().trim();
+    if (!query) {
+      return historyDoc.entries || [];
+    }
+
+    return (historyDoc.entries || []).filter((entry) => {
+      const titleMatch = entry.docTitle?.toLowerCase().includes(query);
+      const urlMatch = entry.docUrl?.toLowerCase().includes(query);
+      return titleMatch || urlMatch;
+    });
+  });
+
+  // Group entries by date (returns array of [dateString, entries] tuples)
+  const groupedByDate = createMemo(() => {
+    const groups = new Map<string, HistoryEntry[]>();
+
+    // Reverse to show most recent first
+    const entries = [...filteredEntries()].reverse();
+
+    for (const entry of entries) {
+      const date = dateGroupFormatter.format(new Date(entry.timestamp));
+
+      if (!groups.has(date)) {
+        groups.set(date, []);
+      }
+      groups.get(date)!.push(entry);
+    }
+
+    return Array.from(groups);
+  });
+
+  // Group entries by document
+  const groupedByDocument = createMemo(() => {
+    const groups = new Map<AutomergeUrl, HistoryEntry[]>();
+
+    // Reverse to show most recent first within each document group
+    const entries = [...filteredEntries()].reverse();
+
+    for (const entry of entries) {
+      if (!groups.has(entry.docUrl)) {
+        groups.set(entry.docUrl, []);
+      }
+      groups.get(entry.docUrl)!.push(entry);
+    }
+
+    return groups;
+  });
+
+  // Sorted document groups
+  const sortedDocumentGroups = createMemo(() => {
+    const groups = Array.from(groupedByDocument());
+    const sortMode = documentSortMode();
+
+    if (sortMode === "visits") {
+      // Sort by number of visits (descending)
+      return groups.sort((a, b) => b[1].length - a[1].length);
+    } else {
+      // Precompute max timestamps to avoid recalculating in comparator
+      const maxTimestamps = new Map<AutomergeUrl, number>();
+      for (const [url, entries] of groups) {
+        let max = 0;
+        for (const e of entries) {
+          if (e.timestamp > max) max = e.timestamp;
+        }
+        maxTimestamps.set(url, max);
+      }
+      return groups.sort(
+        (a, b) => maxTimestamps.get(b[0])! - maxTimestamps.get(a[0])!
+      );
+    }
+  });
+
+  const openDocument = (entry: HistoryEntry) => {
+    // TODO: it makes sense to load the document at the specific moment in history, but for now
+    // this isn't indicated well in the UI, so it's likely to be confusing.
+    // const url =
+    //   entry.heads.length > 0
+    //     ? (`${entry.docUrl}#${entry.heads[0]}` as AutomergeUrl)
+    //     : entry.docUrl;
+    const url = entry.docUrl;
+
+    // Open document with saved tool
+    props.element.dispatchEvent(
+      new OpenDocumentEvent({
+        url,
+        toolId: entry.toolId,
+      })
+    );
+  };
+
+  const formatTime = (timestamp: number) => {
+    return timeFormatter.format(new Date(timestamp));
+  };
+
+  const formatShortDate = (timestamp: number) => {
+    return shortDateFormatter.format(new Date(timestamp));
+  };
+
+  const deleteEntry = (e: MouseEvent, entryToDelete: HistoryEntry) => {
+    e.stopPropagation();
+
+    props.handle.change((doc) => {
+      const index = doc.entries.findIndex(
+        (e) =>
+          e.timestamp === entryToDelete.timestamp &&
+          e.docUrl === entryToDelete.docUrl
+      );
+      if (index !== -1) {
+        doc.entries.splice(index, 1);
+      }
+    });
+  };
+
+  const toggleGroup = (docUrl: AutomergeUrl) => {
+    setExpandedGroups((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(docUrl)) {
+        newSet.delete(docUrl);
+      } else {
+        newSet.add(docUrl);
+      }
+      return newSet;
+    });
+  };
+
+  const openDocumentGroup = (docUrl: AutomergeUrl) => {
+    // Open document without specifying heads or tool (opens most recent version with default tool)
+    props.element.dispatchEvent(
+      new OpenDocumentEvent({
+        url: docUrl,
+      })
+    );
+  };
+
+  return (
+    <div class="account-history-viewer">
+      <div class="account-history-header">
+        <h1 class="account-history-title">Account History</h1>
+        <div class="account-history-header-controls">
+          <span class="account-history-group-label">Group by:</span>
+          <button
+            onClick={() => setGroupingMode("date")}
+            class={`account-history-toggle-button ${groupingMode() === "date" ? "active" : ""}`}
+          >
+            Date
+          </button>
+          <button
+            onClick={() => setGroupingMode("document")}
+            class={`account-history-toggle-button ${groupingMode() === "document" ? "active" : ""}`}
+          >
+            Document
+          </button>
+          <Show when={groupingMode() === "document"}>
+            <span class="account-history-sort-label">Sort by:</span>
+            <button
+              onClick={() => setDocumentSortMode("recent")}
+              class={`account-history-sort-button ${documentSortMode() === "recent" ? "active" : ""}`}
+            >
+              Most Recent
+            </button>
+            <button
+              onClick={() => setDocumentSortMode("visits")}
+              class={`account-history-sort-button ${documentSortMode() === "visits" ? "active" : ""}`}
+            >
+              Most Visits
+            </button>
+          </Show>
+        </div>
+        <div class="account-history-search">
+          <svg
+            class="account-history-search-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
+          <input
+            type="text"
+            class="account-history-search-input"
+            placeholder="search history"
+            value={searchQuery()}
+            onInput={(e) => setSearchQuery(e.currentTarget.value)}
+          />
+        </div>
+      </div>
+
+      <div class="account-history-content">
+        <Show when={groupingMode() === "date"}>
+          <For each={groupedByDate()}>
+            {([date, entries]) => (
+              <div class="account-history-group">
+                <div class="account-history-group-header">
+                  <h2 class="account-history-group-title">{date}</h2>
+                </div>
+                <div class="account-history-entries">
+                  <For each={entries}>
+                    {(entry) => (
+                      <HistoryEntryRow
+                        entry={entry}
+                        timeDisplay={formatTime(entry.timestamp)}
+                        urlDisplay={entry.docUrl}
+                        onOpen={openDocument}
+                        onDelete={deleteEntry}
+                      />
+                    )}
+                  </For>
+                </div>
+              </div>
+            )}
+          </For>
+        </Show>
+
+        <Show when={groupingMode() === "document"}>
+          <For each={sortedDocumentGroups()}>
+            {([docUrl, entries]) => {
+              const isExpanded = () => expandedGroups().has(docUrl);
+
+              return (
+                <div class="account-history-group">
+                  <div
+                    class="account-history-group-header account-history-group-header-clickable"
+                    onClick={() => openDocumentGroup(docUrl)}
+                  >
+                    <div class="account-history-group-header-content">
+                      <h2 class="account-history-group-title">
+                        {entries[0]?.docTitle ?? "Untitled"}
+                      </h2>
+                      <p class="account-history-group-meta">
+                        {entries[0]?.docType ?? "unknown"} • {entries.length}{" "}
+                        {entries.length === 1 ? "visit" : "visits"}
+                      </p>
+                    </div>
+                    <button
+                      class="account-history-group-toggle"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleGroup(docUrl);
+                      }}
+                      aria-label={isExpanded() ? "Collapse" : "Expand"}
+                      title={isExpanded() ? "Collapse" : "Expand"}
+                    >
+                      {isExpanded() ? "−" : "+"}
+                    </button>
+                  </div>
+                  <Show when={isExpanded()}>
+                    <div class="account-history-entries">
+                      <For each={entries}>
+                        {(entry) => (
+                          <HistoryEntryRow
+                            entry={entry}
+                            timeDisplay={formatShortDate(entry.timestamp)}
+                            urlDisplay={`(#${entry.heads})`}
+                            onOpen={openDocument}
+                            onDelete={deleteEntry}
+                          />
+                        )}
+                      </For>
+                    </div>
+                  </Show>
+                </div>
+              );
+            }}
+          </For>
+        </Show>
+
+        <Show when={!historyDoc.entries || historyDoc.entries.length === 0}>
+          <div class="account-history-empty">
+            No history yet. Open some documents to start tracking your history.
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/tools/tiny-patchwork/account-history/src/constants.ts
+++ b/tools/tiny-patchwork/account-history/src/constants.ts
@@ -1,0 +1,4 @@
+export const ACCOUNT_HISTORY_DATATYPE = "patchwork:account-history";
+// if the same document is opened again within this time, we consider it a duplicate and don't record it again
+export const DEDUPLICATION_TIME_THRESHOLD = 500; // milliseconds
+export const VIEWER_TOOL_ID = "account-history-viewer";

--- a/tools/tiny-patchwork/account-history/src/index.css
+++ b/tools/tiny-patchwork/account-history/src/index.css
@@ -1,0 +1,497 @@
+:root {
+  /* Light mode colors */
+  --account-history-primary: #1a73e8;
+  --account-history-bg: #ffffff;
+  --account-history-text: #202124;
+  --account-history-text-secondary: #5f6368;
+  --account-history-text-tertiary: #80868b;
+  --account-history-border: #e0e0e0;
+  --account-history-hover: #f1f3f4;
+  --account-history-radius: 4px;
+
+  /* Danger/delete colors */
+  --account-history-danger: #d93025;
+  --account-history-danger-bg: rgba(217, 48, 37, 0.1);
+
+  /* Fluid spacing scale - scales smoothly from mobile to desktop */
+  --account-history-space-2xs: 0.25rem;                        /* 4px - fixed minimal spacing */
+  --account-history-space-xs: clamp(0.375rem, 0.5vw, 0.5rem);  /* 6px → 8px */
+  --account-history-space-sm: clamp(0.5rem, 1vw, 0.75rem);     /* 8px → 12px */
+  --account-history-space-md: clamp(0.75rem, 2vw, 1rem);       /* 12px → 16px */
+  --account-history-space-lg: clamp(1rem, 2.5vw, 1.5rem);      /* 16px → 24px */
+  --account-history-space-xl: 2rem;                            /* 32px - fixed large spacing */
+  --account-history-space-2xl: 4rem;                           /* 64px - fixed extra large spacing */
+
+  /* Fluid typography scale - scales smoothly across viewports */
+  --account-history-text-2xs: clamp(0.625rem, 0.5vw + 0.5rem, 0.6875rem);    /* 10px → 11px */
+  --account-history-text-xs: clamp(0.6875rem, 0.5vw + 0.625rem, 0.8125rem);  /* 11px → 13px */
+  --account-history-text-sm: clamp(0.75rem, 0.5vw + 0.6875rem, 0.875rem);    /* 12px → 14px */
+  --account-history-text-base: clamp(0.8125rem, 0.5vw + 0.75rem, 0.9375rem); /* 13px → 15px */
+  --account-history-text-md: clamp(0.875rem, 0.5vw + 0.8125rem, 1rem);       /* 14px → 16px */
+  --account-history-text-lg: clamp(1rem, 1vw + 0.875rem, 1.125rem);          /* 16px → 18px */
+  --account-history-text-xl: clamp(1.125rem, 1.5vw + 0.9375rem, 1.25rem);    /* 18px → 20px */
+  --account-history-text-2xl: clamp(1.25rem, 2vw + 1rem, 1.375rem);          /* 20px → 22px */
+
+  /* Icon sizes */
+  --account-history-icon-xs: 0.875rem;   /* 14px */
+  --account-history-icon-sm: 1rem;       /* 16px */
+  --account-history-icon-md: 1.125rem;   /* 18px */
+  --account-history-icon-lg: 1.25rem;    /* 20px */
+  --account-history-icon-xl: 1.5rem;     /* 24px */
+  --account-history-icon-2xl: 1.75rem;   /* 28px */
+
+  /* Button/touch target sizes */
+  --account-history-touch-sm: 1.75rem;   /* 28px */
+  --account-history-touch-md: 2rem;      /* 32px */
+  --account-history-touch-lg: 2.75rem;   /* 44px - WCAG minimum touch target */
+
+  /* Transition timing */
+  --account-history-transition-fast: 0.15s;
+  --account-history-transition-base: 0.2s;
+  --easing: ease;
+
+  /* Z-index scale */
+  --account-history-z-sticky-date: 5;
+  --account-history-z-sticky-header: 10;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    /* Dark mode colors */
+    --account-history-primary: #8ab4f8;
+    --account-history-bg: #1a1a1a;
+    --account-history-text: #e8eaed;
+    --account-history-text-secondary: #9aa0a6;
+    --account-history-text-tertiary: #6e6e6e;
+    --account-history-border: #3a3a3a;
+    --account-history-hover: #2a2a2a;
+  }
+}
+
+/* History Recorder (toolbar button) */
+.account-history-toolbar-button {
+  padding: 0.5rem;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--account-history-text);
+  transition: opacity 0.2s ease;
+}
+
+.account-history-toolbar-button:hover {
+  opacity: 0.7;
+}
+
+/* History Viewer */
+.account-history-viewer {
+  padding: var(--account-history-space-md);
+  width: 100%;
+  height: 100%;
+  margin: 0 auto;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  color: var(--account-history-text);
+  background: var(--account-history-bg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.account-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--account-history-space-md);
+  padding-bottom: var(--account-history-space-md);
+  border-bottom: 1px solid var(--account-history-border);
+  flex-shrink: 0;
+  gap: var(--account-history-space-md);
+  flex-wrap: wrap;
+  background: var(--account-history-bg);
+  position: sticky;
+  top: 0;
+  z-index: var(--account-history-z-sticky-header);
+  margin-left: calc(-1 * var(--account-history-space-md));
+  margin-right: calc(-1 * var(--account-history-space-md));
+  margin-top: calc(-1 * var(--account-history-space-md));
+  padding-left: var(--account-history-space-md);
+  padding-right: var(--account-history-space-md);
+  padding-top: var(--account-history-space-md);
+}
+
+.account-history-header-controls {
+  display: flex;
+  gap: var(--account-history-space-xs);
+  align-items: center;
+}
+
+.account-history-group-label {
+  font-size: var(--account-history-text-base);
+  color: var(--account-history-text-secondary);
+  font-weight: 500;
+}
+
+.account-history-search {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.account-history-search-icon {
+  position: absolute;
+  left: var(--account-history-space-sm);
+  width: var(--account-history-icon-md);
+  height: var(--account-history-icon-md);
+  color: var(--account-history-text-tertiary);
+  pointer-events: none;
+}
+
+.account-history-search-input {
+  width: 100%;
+  padding: var(--account-history-space-xs) var(--account-history-space-sm) var(--account-history-space-xs) 2.375rem;
+  border: 1px solid var(--account-history-border);
+  border-radius: var(--account-history-radius);
+  background: var(--account-history-bg);
+  color: var(--account-history-text);
+  font-size: var(--account-history-text-md);
+  font-family: inherit;
+  transition: border-color var(--account-history-transition-fast) var(--easing);
+}
+
+.account-history-search-input::placeholder {
+  color: var(--account-history-text-tertiary);
+}
+
+.account-history-search-input:focus {
+  outline: none;
+  border-color: var(--account-history-primary);
+}
+
+.account-history-sort-label {
+  font-size: var(--account-history-text-base);
+  color: var(--account-history-text-secondary);
+  font-weight: 500;
+  margin-left: var(--account-history-space-md);
+}
+
+.account-history-sort-button {
+  padding: 0.375rem var(--account-history-space-sm);
+  border-radius: var(--account-history-radius);
+  border: 1px solid var(--account-history-border);
+  background: var(--account-history-bg);
+  cursor: pointer;
+  font-size: var(--account-history-text-base);
+  color: var(--account-history-text);
+  transition: background-color var(--account-history-transition-fast) var(--easing);
+  font-weight: 500;
+}
+
+.account-history-sort-button:hover {
+  background: var(--account-history-hover);
+}
+
+.account-history-sort-button.active {
+  background: var(--account-history-primary);
+  color: var(--account-history-bg);
+  border-color: var(--account-history-primary);
+}
+
+.account-history-title {
+  margin: 0;
+  font-size: var(--account-history-text-2xl);
+  font-weight: 600;
+  color: var(--account-history-text);
+}
+
+.account-history-toggle-button {
+  padding: var(--account-history-space-xs) var(--account-history-space-md);
+  border-radius: var(--account-history-radius);
+  border: 1px solid var(--account-history-border);
+  background: var(--account-history-bg);
+  cursor: pointer;
+  font-size: var(--account-history-text-base);
+  color: var(--account-history-text);
+  transition: background-color var(--account-history-transition-fast) var(--easing);
+  font-weight: 500;
+}
+
+.account-history-toggle-button:hover {
+  background: var(--account-history-hover);
+}
+
+.account-history-toggle-button.active {
+  background: var(--account-history-primary);
+  color: var(--account-history-bg);
+  border-color: var(--account-history-primary);
+}
+
+/* Scrollable Content Area */
+.account-history-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+/* History Groups - Flat Design */
+
+.account-history-group-header {
+  margin-bottom: var(--account-history-space-xs);
+  padding: var(--account-history-space-xs) 0;
+}
+
+/* Sticky date headers in date grouping mode */
+.account-history-group-header:not(.account-history-group-header-clickable) {
+  position: sticky;
+  top: 0;
+  background: var(--account-history-bg);
+  z-index: var(--account-history-z-sticky-date);
+  padding-top: var(--account-history-space-sm);
+  margin-top: calc(-1 * var(--account-history-space-2xs));
+}
+
+.account-history-group-header-clickable {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  transition: background-color var(--account-history-transition-fast) var(--easing);
+  border-radius: var(--account-history-radius);
+  padding: var(--account-history-space-xs) var(--account-history-space-sm);
+}
+
+.account-history-group-header-clickable:hover {
+  background: var(--account-history-hover);
+}
+
+.account-history-group-header-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.account-history-group-toggle {
+  width: var(--account-history-touch-sm);
+  height: var(--account-history-touch-sm);
+  min-width: var(--account-history-touch-sm);
+  border: 1px solid var(--account-history-border);
+  background: var(--account-history-bg);
+  cursor: pointer;
+  border-radius: var(--account-history-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--account-history-text-secondary);
+  font-size: var(--account-history-text-xl);
+  font-weight: 300;
+  transition: all var(--account-history-transition-fast) var(--easing);
+  padding: 0;
+  line-height: 1;
+}
+
+.account-history-group-toggle:hover {
+  background: var(--account-history-primary);
+  color: var(--account-history-bg);
+  border-color: var(--account-history-primary);
+}
+
+.account-history-group-title {
+  font-size: var(--account-history-text-base);
+  font-weight: 600;
+  margin: 0;
+  color: var(--account-history-text-secondary);
+}
+
+.account-history-group-meta {
+  font-size: var(--account-history-text-sm);
+  color: var(--account-history-text-tertiary);
+  margin: var(--account-history-space-2xs) 0 0 0;
+}
+
+.account-history-entries {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+/* History Entry - Flat List Design */
+.account-history-entry {
+  display: grid;
+  /* TODO: icon */
+  /* grid-template-columns: auto 28px 1fr 32px; */
+  grid-template-columns: auto 1fr var(--account-history-touch-md);
+  gap: var(--account-history-space-sm);
+  align-items: center;
+  padding: var(--account-history-space-xs) var(--account-history-space-sm);
+  border-bottom: 1px solid var(--account-history-border);
+  background: var(--account-history-bg);
+  transition: background-color var(--account-history-transition-fast) var(--easing);
+  min-height: var(--account-history-touch-lg);
+}
+
+.account-history-entry:hover {
+  background: var(--account-history-hover);
+}
+
+/* Time Column */
+.account-history-entry-time {
+  font-size: var(--account-history-text-sm);
+  color: var(--account-history-text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Content Column - Clickable */
+.account-history-entry-content {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: var(--account-history-space-xs);
+  min-width: 0;
+  cursor: pointer;
+}
+
+.account-history-entry-title {
+  font-size: var(--account-history-text-base);
+  font-weight: 500;
+  color: var(--account-history-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-history-entry-content:hover .account-history-entry-title {
+  color: var(--account-history-primary);
+}
+
+.account-history-entry-tool {
+  font-size: var(--account-history-text-base);
+  color: var(--account-history-text-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* URL - Secondary Appearance (inline with title/tool) */
+.account-history-entry-url {
+  font-size: var(--account-history-text-xs);
+  color: var(--account-history-text-tertiary);
+  opacity: 0.6;
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, Courier, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+/* Actions Column */
+.account-history-entry-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.account-history-entry-delete {
+  width: var(--account-history-icon-xl);
+  height: var(--account-history-icon-xl);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: var(--account-history-radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--account-history-text-tertiary);
+  transition: all var(--account-history-transition-fast) var(--easing);
+  padding: 0;
+  opacity: 0;
+}
+
+.account-history-entry:hover .account-history-entry-delete {
+  opacity: 1;
+}
+
+.account-history-entry-delete:hover {
+  background: var(--account-history-danger-bg);
+  color: var(--account-history-danger);
+}
+
+.account-history-entry-delete svg {
+  width: var(--account-history-icon-sm);
+  height: var(--account-history-icon-sm);
+}
+
+/* Empty State */
+.account-history-empty {
+  padding: var(--account-history-space-2xl) var(--account-history-space-lg);
+  text-align: center;
+  color: var(--account-history-text-tertiary);
+  font-size: var(--account-history-text-md);
+}
+
+/* Responsive Design */
+
+/* Mobile (<640px) */
+@media (max-width: 640px) {
+  .account-history-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .account-history-header-controls {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .account-history-toggle-button {
+    flex: 1;
+  }
+
+  .account-history-sort-label {
+    margin-left: 0;
+    margin-top: var(--account-history-space-xs);
+    width: 100%;
+  }
+
+  .account-history-sort-button {
+    flex: 1;
+  }
+
+  .account-history-group {
+    margin-bottom: var(--account-history-space-lg);
+  }
+
+  .account-history-entry {
+    grid-template-columns: 1fr var(--account-history-touch-sm);
+    grid-template-rows: auto auto;
+    gap: var(--account-history-space-2xs) var(--account-history-space-xs);
+    min-height: auto;
+  }
+
+  .account-history-entry-time {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+  }
+
+  .account-history-entry-content {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
+  }
+
+  .account-history-entry-url {
+    display: none;
+  }
+
+  .account-history-entry-actions {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+  }
+
+  .account-history-entry-delete {
+    opacity: 1;
+  }
+
+}

--- a/tools/tiny-patchwork/account-history/src/index.tsx
+++ b/tools/tiny-patchwork/account-history/src/index.tsx
@@ -1,0 +1,70 @@
+import { render } from "solid-js/web";
+import { type ToolImplementation } from "@inkandswitch/patchwork-plugins";
+import { ACCOUNT_HISTORY_DATATYPE, VIEWER_TOOL_ID } from "./constants.ts";
+import type { HistoryDoc } from "./types.ts";
+import "./index.css";
+
+export const plugins = [
+  {
+    id: ACCOUNT_HISTORY_DATATYPE,
+    type: "patchwork:datatype",
+    name: "Account History",
+    icon: "Clock",
+    async load() {
+      return {
+        getTitle: (doc: HistoryDoc) => doc.title || "Account History",
+        create: (): HistoryDoc => ({
+          ["@patchwork"]: { type: ACCOUNT_HISTORY_DATATYPE },
+          title: "Account History",
+          entries: [],
+        }),
+      };
+    },
+  },
+  {
+    id: "account-history-toolbar",
+    type: "patchwork:tool",
+    tags: ["titlebar-tool"],
+    name: "Account History Recorder",
+    supportedDatatypes: ["account"],
+    icon: "Clock",
+    unlisted: true,
+    async load(): Promise<ToolImplementation<any>> {
+      const { HistoryRecorder } = await import("./HistoryRecorder.tsx");
+      return (handle, element) => {
+        return render(
+          () => (
+            <HistoryRecorder
+              handle={handle}
+              repo={element.repo}
+              element={element}
+            />
+          ),
+          element
+        );
+      };
+    },
+  },
+  {
+    id: VIEWER_TOOL_ID,
+    type: "patchwork:tool",
+    name: "Account History Viewer",
+    supportedDatatypes: [ACCOUNT_HISTORY_DATATYPE],
+    icon: "Clock",
+    async load(): Promise<ToolImplementation<HistoryDoc>> {
+      const { HistoryViewer } = await import("./HistoryViewer.tsx");
+      return (handle, element) => {
+        return render(
+          () => (
+            <HistoryViewer
+              handle={handle}
+              repo={element.repo}
+              element={element}
+            />
+          ),
+          element
+        );
+      };
+    },
+  },
+];

--- a/tools/tiny-patchwork/account-history/src/types.ts
+++ b/tools/tiny-patchwork/account-history/src/types.ts
@@ -1,0 +1,27 @@
+import type { AutomergeUrl, DocHandle, Repo } from "@automerge/automerge-repo";
+import type { PatchworkViewElement } from "@inkandswitch/patchwork-elements";
+
+export interface PatchworkToolProps<T> {
+  handle: DocHandle<T>;
+  repo: Repo;
+  element: PatchworkViewElement;
+}
+
+export type HistoryDoc = {
+  "@patchwork": { type: "patchwork:account-history" };
+  title: string;
+  entries: HistoryEntry[];
+};
+
+export type HistoryEntry = {
+  timestamp: number; // when opened (milliseconds since epoch)
+  docUrl: AutomergeUrl; // document URL
+  docTitle: string; // title at open time
+  docType: string; // document type
+  toolId: string; // tool used
+  heads: string[]; // automerge heads at open time
+};
+
+export type AccountDoc = {
+  accountHistoryUrl?: AutomergeUrl;
+} & Record<string, unknown>;

--- a/tools/tiny-patchwork/account-history/src/vite-env.d.ts
+++ b/tools/tiny-patchwork/account-history/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/tools/tiny-patchwork/account-history/tsconfig.json
+++ b/tools/tiny-patchwork/account-history/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/tools/tiny-patchwork/account-history/vite.config.ts
+++ b/tools/tiny-patchwork/account-history/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
+import externals from "@inkandswitch/patchwork-bootloader/externals";
+
+export default defineConfig({
+  base: "./",
+  plugins: [solid(), cssInjectedByJsPlugin()],
+
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    rollupOptions: {
+      external: externals,
+      input: "./src/index.tsx",
+      output: {
+        format: "es",
+        entryFileNames: "[name].js",
+        chunkFileNames: "assets/[name]-[hash].js",
+        assetFileNames: "assets/[name][extname]",
+      },
+      preserveEntrySignatures: "strict",
+    },
+  },
+});


### PR DESCRIPTION
This PR adds basic initial implementations of the following:

- a new datatype for documents that track account history (the history of which documents are viewed when and with which tools)
- a tool for recording document open events into the account's account-history document
- a tool for viewing account-history documents