### PR TITLE
rewrite bare imports in js files

### DIFF
--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -41,6 +41,7 @@
     "@inkandswitch/patchwork-filesystem": "workspace:^",
     "@types/debug": "^4.1.12",
     "debug": "^4.4.3",
+    "es-module-lexer": "^2.0.0",
     "resolve.exports": "^2.0.3",
     "service-worker-types": "npm:@types/serviceworker@^0.0.153",
     "tinyargs": "^0.1.4"

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -12,11 +12,14 @@ import {
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
+  type AutomergeUrl,
   type PeerId,
 } from "@automerge/automerge-repo/slim";
 import {
   findHandleInFolderHandle,
   resolvePackageExport,
+  getImportableUrlFromAutomergeUrl,
+  defaultImportConditions,
   type FolderDoc,
 } from "@inkandswitch/patchwork-filesystem";
 
@@ -24,6 +27,17 @@ import {
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel";
+
+// Small — bundled directly into the SW
+import { init as lexerReady, parse as parseImports } from "es-module-lexer";
+import externals from "./externals.js";
+
+// Build-time importmap: bare specifier → URL for shared/builtin packages.
+// When an automerge-served JS file does `import "solid-js"`, we resolve
+// it to /packages/solid-js.js without touching automerge at all.
+const builtinImports: Record<string, string> = Object.fromEntries(
+  externals.map((name) => [name, `/packages/${name}.js`])
+);
 
 let cachename = "default";
 let debugging = false;
@@ -124,6 +138,173 @@ self.addEventListener("message", async (event) => {
 interface FileDoc {
   content: string | Uint8Array;
   mimeType?: string;
+}
+
+// ── Bare import rewriting ──────────────────────────────────────────────
+
+function isBareSpecifier(specifier: string): boolean {
+  return (
+    specifier.length > 0 &&
+    !specifier.startsWith(".") &&
+    !specifier.startsWith("/") &&
+    !specifier.includes(":")
+  );
+}
+
+/**
+ * Given a folder's automerge URL, read its package.json or importmap.json
+ * and return the dependency map: { "lol": "automerge:defghi", ... }
+ */
+async function getDependencyMap(
+  repo: Repo,
+  folderUrl: AutomergeUrl
+): Promise<Record<string, string> | undefined> {
+  const folderHandle = await repo.find<FolderDoc>(folderUrl);
+
+  for (const name of ["package.json", "importmap.json"]) {
+    const fileHandle = await findHandleInFolderHandle<FileDoc>(
+      repo,
+      folderHandle,
+      [name]
+    );
+    if (!fileHandle) continue;
+
+    const fileDoc = fileHandle.doc() as FileDoc | undefined;
+    if (!fileDoc?.content) continue;
+
+    const json = JSON.parse(String(fileDoc.content));
+
+    if (name === "importmap.json") {
+      return json.imports;
+    } else {
+      return json.dependencies;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Given a dep's automerge URL and a subpath (e.g. "." or "./utils"),
+ * resolve the entry point via package.json exports and return
+ * the full SW-handoff URL path (e.g. /automerge%3Adefghi/dist/index.js).
+ */
+async function resolveDepEntryPoint(
+  repo: Repo,
+  depAutomergeUrl: AutomergeUrl,
+  subpath: string = ".",
+  conditions: string[] = defaultImportConditions
+): Promise<string | undefined> {
+  const folderHandle = await repo.find<FolderDoc>(depAutomergeUrl);
+  const pkgFileHandle = await findHandleInFolderHandle<FileDoc>(
+    repo,
+    folderHandle,
+    ["package.json"]
+  );
+  if (!pkgFileHandle) return undefined;
+
+  const pkgFileDoc = pkgFileHandle.doc() as FileDoc | undefined;
+  if (!pkgFileDoc?.content) return undefined;
+
+  const pkgJson = JSON.parse(String(pkgFileDoc.content));
+
+  let entryPoint: string | undefined;
+  try {
+    entryPoint = resolvePackageExport(pkgJson, subpath, conditions);
+  } catch {}
+
+  if (!entryPoint) return undefined;
+
+  return getImportableUrlFromAutomergeUrl(depAutomergeUrl, entryPoint);
+}
+
+/**
+ * Rewrite bare import specifiers in JS source to resolved URLs.
+ * Checks builtins first (/packages/...), then the folder's dependency map.
+ */
+async function rewriteBareImports(
+  source: string,
+  rootAutomergeUrl: AutomergeUrl,
+  repo: Repo
+): Promise<string> {
+  await lexerReady;
+  const [imports] = parseImports(source);
+
+  if (!imports.length) return source;
+
+  // Collect bare specifiers
+  const bareSpecifiers = new Set<string>();
+  for (const imp of imports) {
+    if (imp.n && isBareSpecifier(imp.n)) {
+      bareSpecifiers.add(imp.n);
+    }
+  }
+
+  if (!bareSpecifiers.size) return source;
+
+  // Fetch the dependency map from the root folder
+  const deps = await getDependencyMap(repo, rootAutomergeUrl);
+
+  // Build a resolution map: bare specifier → resolved URL
+  const resolutions = new Map<string, string>();
+  for (const specifier of bareSpecifiers) {
+    // 1. Check builtins first (solid-js, @automerge/automerge, etc.)
+    if (builtinImports[specifier]) {
+      resolutions.set(specifier, builtinImports[specifier]);
+      continue;
+    }
+
+    if (!deps) continue;
+
+    // 2. Split "lol/utils" into package name "lol" and subpath "./utils"
+    const firstSlash = specifier.indexOf("/");
+    const isScoped = specifier.startsWith("@");
+    let pkgName: string;
+    let subpath: string;
+
+    if (isScoped) {
+      const secondSlash = specifier.indexOf("/", firstSlash + 1);
+      if (secondSlash === -1) {
+        pkgName = specifier;
+        subpath = ".";
+      } else {
+        pkgName = specifier.slice(0, secondSlash);
+        subpath = "./" + specifier.slice(secondSlash + 1);
+      }
+    } else if (firstSlash === -1) {
+      pkgName = specifier;
+      subpath = ".";
+    } else {
+      pkgName = specifier.slice(0, firstSlash);
+      subpath = "./" + specifier.slice(firstSlash + 1);
+    }
+
+    const depValue = deps[pkgName];
+    if (!depValue) continue;
+
+    if (isValidAutomergeUrl(depValue)) {
+      const entryUrl = await resolveDepEntryPoint(repo, depValue, subpath);
+      if (entryUrl) {
+        resolutions.set(specifier, entryUrl);
+      }
+    }
+  }
+
+  if (!resolutions.size) return source;
+
+  // Rewrite the source string, working backwards to preserve offsets
+  let result = source;
+  const sorted = [...imports]
+    .filter((imp) => imp.n && resolutions.has(imp.n))
+    .sort((a, b) => b.s - a.s);
+
+  for (const imp of sorted) {
+    const resolved = resolutions.get(imp.n!);
+    if (!resolved) continue;
+    result = result.slice(0, imp.s) + resolved + result.slice(imp.e);
+  }
+
+  return result;
 }
 
 // ── Automerge URL resolution ───────────────────────────────────────────
@@ -240,6 +421,26 @@ async function resolveAutomergeUrl(automergeURL: URL): Promise<Response> {
       ? (new Uint8Array(content) as BlobPart)
       : String(content);
   const mimeType = fileDoc.mimeType ?? "text/plain";
+
+  // Rewrite bare imports in JS files served from automerge folders
+  const lastPart = path[path.length - 1];
+  const isJS =
+    mimeType === "application/javascript" ||
+    mimeType === "text/javascript" ||
+    lastPart?.endsWith(".js") ||
+    lastPart?.endsWith(".mjs");
+
+  if (isJS && typeof content === "string") {
+    try {
+      body = await rewriteBareImports(
+        content,
+        maybeAutomergeUrl as AutomergeUrl,
+        repo
+      );
+    } catch (e) {
+      log("failed to rewrite bare imports", e);
+    }
+  }
 
   const headers = new Headers({ "content-type": mimeType });
   headers.set("cross-origin-embedder-policy", "credentialless");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       debug:
         specifier: ^4.4.3
         version: 4.4.3
+      es-module-lexer:
+        specifier: ^2.0.0
+        version: 2.0.0
       resolve.exports:
         specifier: ^2.0.3
         version: 2.0.3
@@ -6677,6 +6680,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild-plugin-tailwindcss@2.1.0:
     resolution: {integrity: sha512-Mqd9Dko8fHGOWVhN53wXefAZZ45i5sZVY3XvyFN5ZKhOPpxXrducAcDPE5iqFw0aJoEm6MG1V9x4Kz6TiQV9kQ==}
@@ -13426,6 +13432,8 @@ snapshots:
   entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild-plugin-tailwindcss@2.1.0:
     dependencies:


### PR DESCRIPTION
How do we do dependencies between automerge: folder docs in Patchwork?

How do we publish libraries without relying on npmjs.org?

## the problem

There are three times when dependencies need to present themselves in some way during the development process.

1. Type hints when editing code in your text editor
2. When bundling
3. At runtime

For #1, we'd like to pull files from automerge folder docs and populate the `node_modules/` directory.

For #2 and #3, it would be nice if we didn't compile our automerge: code into every bundle, but Patchwork was able to resolve it at build time.

## the proposal

A three pronged attack. 

### 1. we use a [custom pnpm fetcher/resolver](https://github.com/pnpm/pnpm/pull/10246) (a feature coming in the [next version](https://github.com/pnpm/pnpm/releases/tag/v11.0.0-alpha.16) of pnpm) that materializes `automerge:` docs into the `node_modules` dir
### 2. a bundler plugin that externalizes `automerge:` imports when bundling.
### 3. in the service worker we rewrite bare imports in javascript files to the correct automerge url based on what's in their package.json

### explanation

imagine a js file like this:

`xyz/index.js`:

```js
import "abc"
```

and a package.json like this:

`xyz/package.json`:
```json
{
  "name": "xyz",
  "dependencies": {
    "abc": "automerge:abcdefg"
  }
}
```

- this PR
  - rewrites `import "abc"` to `import "/automerge%3Aabcdefg/path/to/entry.js"` 
- this resolver for the next version of pnpm: https://github.com/chee/pnpm-resolver-patchwork
  - `pnpm install` pulls `automerge:abcd` into the node modules
  - yay, types!
- an as-of-yet not made bundler plugin to be built with https://github.com/unjs/unplugin
  - automatically externalizes any dep beginning with `automerge:`

together, we have a system for dependencies that includes 0 new ideas

## what's wrong with this?

- packages that are like this no longer make sense without the pnpm resolver
    - a package like this published to pnpm only loads in patchwork
    - THOUGH we could use export conditions, and bundle the deps in when publishing for node/browser
- we're tied to pnpm
  - until other package managers add a custom spec resolver system
- ties us further to our current doc folder shape that we
- we are rewriting javascript in the service worker. slippery slope?

## what else could we do?

### import maps

i think guy bedford does this crazy thing with non-standard post-esm dynamic import maps that we could do, but it seems just as weird and maybe weirder because it isn't as _obviously_ weird? because it quietly extends a standard with something unlikely to ever be standardized

### use the pnpm resolver and bundle

we get the types this way, but we end up running multiple versions of the same code all over the place

### nothing

keep on publishing to npm

keep on feeling the pain

keep propping up the old world and making more monopoly money