### PR TITLE
Registry fixes

### DIFF
--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -130,16 +130,16 @@ export function registerPatchworkViewElement(
       // each time the element is moved to a different place in the DOM via Element.moveBefore()
       connectedMoveCallback() {}
 
-      attributeChangedCallback(name: string, _: string, val: string | null) {
+      attributeChangedCallback(name: string, old: string | null, val: string | null) {
+        if (old === val) return;
+
         if (name === attrs.toolId) {
-          if (this.toolId != val) {
-            this.toolId = val;
-            this.#teardown().then(() => this.#init());
-          }
+          this.#toolId = val;
+          this.#teardown().then(() => this.#init());
         }
 
         if (name === attrs.docUrl) {
-          this.docUrl = val as AutomergeUrl;
+          this.#docUrl = val as AutomergeUrl;
           this.#teardown().then(() => this.#init());
         }
       }
@@ -311,7 +311,7 @@ export function registerPatchworkViewElement(
         if (!this.#tool.module) {
           const toolRegistry = getRegistry("patchwork:tool");
           toolRegistry.load(this.#tool.id);
-          if (toolRegistry.loading.has(this.#tool.id)) {
+          if (toolRegistry.isLoading(this.#tool.id)) {
             this.#state = "unable";
             log(`loading ${toolId}`);
             this.#displayLoading(toolId);
@@ -324,10 +324,11 @@ export function registerPatchworkViewElement(
 
         try {
           const cleanup = this.#tool.module(this.#handle, this);
-          if (typeof cleanup != "function") {
+          if (typeof cleanup === "function") {
+            this.#teardowns.add(cleanup);
+          } else {
             console.warn(`return a cleanup function from ${toolId}`);
           }
-          this.#teardowns.add(cleanup);
           this.#state = fallingBack ? "fallback" : "rendered";
           this.dispatchEvent(new MountedEvent({ url: this.docUrl, toolId }));
         } catch (error) {

--- a/core/filesystem/src/module-watcher.ts
+++ b/core/filesystem/src/module-watcher.ts
@@ -31,6 +31,7 @@ export class ModuleWatcher {
   urls: AutomergeUrl[];
   handles: DocHandle<ModuleSettingsDoc>[] | undefined;
   doneLoading: Promise<void>;
+  #watchedModules = new Set<string>();
 
   onLoad: (name: string, mod: any) => void;
 
@@ -82,7 +83,7 @@ export class ModuleWatcher {
   async loadSuggestedImportUrl(docUrl: AutomergeUrl) {
     const handle = await this.repo.find<Partial<HasPatchworkMetadata>>(docUrl);
     const doc = handle.doc();
-    const url = doc["@patchwork"]?.suggestedImportUrl;
+    const url = doc?.["@patchwork"]?.suggestedImportUrl;
     return url && (await this.loadModules([url]));
   }
 
@@ -112,17 +113,19 @@ export class ModuleWatcher {
   // It would be better to watch all the files in the folder recursively
   // and to have some relationship with those other than just parsing the URL.
   private setDocWatcher(importName: string) {
+    if (this.#watchedModules.has(importName)) return;
+    this.#watchedModules.add(importName);
+
     const docUrl = isValidAutomergeUrl(importName)
       ? importName
       : (importName.match(/\/automerge\/(\w+)\//)?.[1] as DocumentId);
 
-    // This is probably a built-in, which is fine!
     if (!docUrl) return;
 
     this.repo.find<FolderDoc>(docUrl).then((handle) => {
-      let previousSyncAtTime = handle.doc().lastSyncAt || 0;
+      let previousSyncAtTime = handle.doc()?.lastSyncAt || 0;
       handle.on("change", () => {
-        const lastSyncAt = handle.doc().lastSyncAt || 0;
+        const lastSyncAt = handle.doc()?.lastSyncAt || 0;
         if (lastSyncAt <= previousSyncAtTime) {
           console.log("handle updated but not lastSyncAt");
           return;

--- a/core/filesystem/src/module-watcher.ts
+++ b/core/filesystem/src/module-watcher.ts
@@ -5,13 +5,9 @@ import {
   isValidAutomergeUrl,
   type Repo,
 } from "@automerge/automerge-repo/slim";
-import {
-  importModuleFromFolderDocUrl,
-  resolvePackageExport,
-} from "./packages.js";
+import { importModuleFromFolderDocUrl } from "./packages.js";
 import type { HasPatchworkMetadata } from "./metadata.js";
 import { FolderDoc } from "./types.js";
-import { getImportableUrlFromAutomergeUrl } from "./urls.js";
 
 export type ModuleSettingsDoc = {
   modules: AutomergeUrl[];
@@ -83,7 +79,7 @@ export class ModuleWatcher {
   async loadSuggestedImportUrl(docUrl: AutomergeUrl) {
     const handle = await this.repo.find<Partial<HasPatchworkMetadata>>(docUrl);
     const doc = handle.doc();
-    const url = doc?.["@patchwork"]?.suggestedImportUrl;
+    const url = doc["@patchwork"]?.suggestedImportUrl;
     return url && (await this.loadModules([url]));
   }
 
@@ -123,9 +119,9 @@ export class ModuleWatcher {
     if (!docUrl) return;
 
     this.repo.find<FolderDoc>(docUrl).then((handle) => {
-      let previousSyncAtTime = handle.doc()?.lastSyncAt || 0;
+      let previousSyncAtTime = handle.doc().lastSyncAt || 0;
       handle.on("change", () => {
-        const lastSyncAt = handle.doc()?.lastSyncAt || 0;
+        const lastSyncAt = handle.doc().lastSyncAt || 0;
         if (lastSyncAt <= previousSyncAtTime) {
           console.log("handle updated but not lastSyncAt");
           return;

--- a/core/plugins/src/registry/guards.ts
+++ b/core/plugins/src/registry/guards.ts
@@ -54,11 +54,5 @@ export function isPlugin<
   T extends PluginDescription = PluginDescription,
   I = any,
 >(value: unknown): value is Plugin<T, I> {
-  if (isPluginDescription<T>(value)) {
-    return true;
-  }
-  if (isLoadablePlugin<T, I>(value)) {
-    return true;
-  }
-  return false;
+  return isPluginDescription<T>(value);
 }

--- a/core/plugins/src/registry/index.ts
+++ b/core/plugins/src/registry/index.ts
@@ -72,6 +72,21 @@ export function registerPlugins<D extends PluginDescription, I>(
 }
 
 /**
+ * Remove all plugins that were registered from a given importUrl.
+ * This is the counterpart to registerPlugins() and is used when a module
+ * is unloaded.
+ */
+export function unregisterPlugins(importUrl: string) {
+  for (const registry of Object.values(registries)) {
+    for (const plugin of registry.all()) {
+      if (plugin.importUrl === importUrl) {
+        registry.remove(plugin.id);
+      }
+    }
+  }
+}
+
+/**
  * Get all registries
  */
 export function getAllRegistries(): Map<string, PluginRegistry<any>> {

--- a/core/plugins/src/registry/index.ts
+++ b/core/plugins/src/registry/index.ts
@@ -29,7 +29,8 @@ export function getRegistry<T extends PluginDescription>(
   return registries[type] as PluginRegistry<T>;
 }
 
-// TODO: remove this
+// todo remove this tomorrow
+// ugly and transitional
 function migrate(plugin: LoadablePlugin) {
   if (plugin.type == "patchwork:tool") {
     const tool = plugin as Tool;

--- a/core/plugins/src/registry/index.ts
+++ b/core/plugins/src/registry/index.ts
@@ -1,3 +1,4 @@
+import type { Tool } from "../tools.js";
 import { PluginRegistry } from "./registry.js";
 import { LoadablePlugin, PluginDescription } from "./types.js";
 
@@ -28,6 +29,28 @@ export function getRegistry<T extends PluginDescription>(
   return registries[type] as PluginRegistry<T>;
 }
 
+// TODO: remove this
+function migrate(plugin: LoadablePlugin) {
+  if (plugin.type == "patchwork:tool") {
+    const tool = plugin as Tool;
+    if ("supportedDataTypes" in tool) {
+      console.warn(
+        plugin.id,
+        plugin.importUrl,
+        "supportedDataTypes was renamed to supportedDatatypes (lowercase t in types). fix it to get rid of this warning"
+      );
+      tool.supportedDatatypes = tool.supportedDataTypes as string[];
+    }
+  } else if (plugin.type == "patchwork:dataType") {
+    console.warn(
+      plugin.id,
+      plugin.importUrl,
+      '"type": "patchwork:dataType" was renamed to patchwork:datatype (lowercase t in type). fix it to get rid of this warning'
+    );
+    plugin.type = "patchwork:datatype";
+  }
+}
+
 /**
  * Register plugins
  */
@@ -41,6 +64,7 @@ export function registerPlugins<D extends PluginDescription, I>(
       console.warn("Plugin has no type", plugin);
       return;
     }
+    migrate(plugin);
     const registry = getRegistry(plugin.type);
     registry.register(plugin, importUrl);
   });

--- a/core/plugins/src/registry/index.ts
+++ b/core/plugins/src/registry/index.ts
@@ -1,4 +1,3 @@
-import type { Tool } from "../tools.js";
 import { PluginRegistry } from "./registry.js";
 import { LoadablePlugin, PluginDescription } from "./types.js";
 
@@ -29,29 +28,6 @@ export function getRegistry<T extends PluginDescription>(
   return registries[type] as PluginRegistry<T>;
 }
 
-// todo remove this tomorrow
-// ugly and transitional
-function migrate(plugin: LoadablePlugin) {
-  if (plugin.type == "patchwork:tool") {
-    const tool = plugin as Tool;
-    if ("supportedDataTypes" in tool) {
-      console.warn(
-        plugin.id,
-        plugin.importUrl,
-        "supportedDataTypes was renamed to supportedDatatypes (lowercase t in types). fix it to get rid of this warning"
-      );
-      tool.supportedDatatypes = tool.supportedDataTypes as string[];
-    }
-  } else if (plugin.type == "patchwork:dataType") {
-    console.warn(
-      plugin.id,
-      plugin.importUrl,
-      '"type": "patchwork:dataType" was renamed to patchwork:datatype (lowercase t in type). fix it to get rid of this warning'
-    );
-    plugin.type = "patchwork:datatype";
-  }
-}
-
 /**
  * Register plugins
  */
@@ -65,7 +41,6 @@ export function registerPlugins<D extends PluginDescription, I>(
       console.warn("Plugin has no type", plugin);
       return;
     }
-    migrate(plugin);
     const registry = getRegistry(plugin.type);
     registry.register(plugin, importUrl);
   });

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -203,6 +203,25 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
   }
 
   /**
+   * Remove a plugin by ID. Emits "removed" and "changed" if the plugin existed.
+   * Returns true if the plugin was found and removed, false if it wasn't registered.
+   */
+  remove(id: string): boolean {
+    if (!this.#plugins.has(id)) {
+      return false;
+    }
+
+    this.#plugins.delete(id);
+    this.#loadPromises.delete(id);
+    this.loading.delete(id);
+
+    this.#events.emit("removed", id);
+    this.#events.emit("changed");
+
+    return true;
+  }
+
+  /**
    * Check if an plugin ID is registered
    */
   has(id: string): boolean {

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -12,8 +12,17 @@ import {
   isLoadedPlugin,
   isPluginDescription,
 } from "./guards.js";
+import type { DatatypeImplementation } from "../datatypes.js";
 
 const log = debug("patchwork:plugins");
+
+function isAsyncFunction(fn: unknown) {
+  return (
+    typeof fn == "function" &&
+    Symbol.toStringTag in fn &&
+    fn[Symbol.toStringTag] == "AsyncFunction"
+  );
+}
 
 /**
  * Registry for managing plugins of a specific type
@@ -114,7 +123,27 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
         }
 
         log(`Successfully loaded implementation for: ${id}`, implementation);
-        const { load, ...descriptionWithoutLoad } = description;
+        // TODO: remove this
+        const desc = description as LoadablePlugin<D, I>;
+        if (desc.type == "patchwork:datatype") {
+          const impl = implementation as DatatypeImplementation;
+          if (isAsyncFunction(impl.getTitle)) {
+            console.warn(
+              desc.id,
+              desc.importUrl,
+              "getTitle should not be an async function"
+            );
+          }
+          if (isAsyncFunction(impl.setTitle)) {
+            console.warn(
+              desc.id,
+              desc.importUrl,
+              "setTitle should not be an async function"
+            );
+          }
+        }
+
+        const { load, ...descriptionWithoutLoad } = desc;
         if (!isPluginDescription<D>(descriptionWithoutLoad)) {
           throw new Error("Invalid plugin description");
         }

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -219,5 +219,4 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
       this.#events.off(event, callback);
     };
   }
-
 }

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -12,17 +12,8 @@ import {
   isLoadedPlugin,
   isPluginDescription,
 } from "./guards.js";
-import type { DatatypeImplementation } from "../datatypes.js";
 
 const log = debug("patchwork:plugins");
-
-function isAsyncFunction(fn: unknown) {
-  return (
-    typeof fn == "function" &&
-    Symbol.toStringTag in fn &&
-    fn[Symbol.toStringTag] == "AsyncFunction"
-  );
-}
 
 /**
  * Registry for managing plugins of a specific type
@@ -126,26 +117,6 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
             module: implementation,
           };
 
-          // todo remove tomorrow
-          // think about where this should live etc
-          if (description.type == "patchwork:datatype") {
-            const impl = implementation as DatatypeImplementation;
-            if (isAsyncFunction(impl.getTitle)) {
-              console.warn(
-                description.id,
-                description.importUrl,
-                "getTitle should not be an async function"
-              );
-            }
-            if (isAsyncFunction(impl.setTitle)) {
-              console.warn(
-                description.id,
-                description.importUrl,
-                "getTitle should be an async function"
-              );
-            }
-          }
-
           // Store the loaded version
           this.#plugins.set(description.id, plugin);
           this.#loadPromises.delete(id);
@@ -183,22 +154,13 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
   async loadAll(plugins: Plugin<D, I>[]): Promise<LoadedPlugin<D, I>[]> {
     // Get all plugins or filter them if a filter function is provided
     // Create an array of promises for loading each plugin
-    const loadPromises = plugins.map(async (plugin) => {
-      try {
-        const Plugin = await this.load(plugin.id);
-        return Plugin;
-      } catch (error) {
-        console.warn(`Failed to load plugin ${plugin.id}:`, error);
-        return undefined;
-      }
-    });
+    const loadPromises = plugins.map((plugin) => this.load(plugin.id));
 
-    // Wait for all plugins to load and filter out any that failed
-    // TODO: use Promise.allSettled instead?
-    // TODO: error handling?
-    const results = await Promise.all(loadPromises);
-    return results.filter(
-      (plugin): plugin is Awaited<LoadedPlugin<D, I>> => plugin !== undefined
+    const results = await Promise.allSettled(loadPromises);
+    return results.flatMap((result) =>
+      result.status === "fulfilled" && result.value !== undefined
+        ? [result.value]
+        : []
     );
   }
 
@@ -228,8 +190,7 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
     return this.#plugins.has(id);
   }
 
-  /** Subscribe to plugin events */
-  // TODO: see if we can / want to reuse the eventemitter3 API here.
+  /** Subscribe to plugin events. Returns an unsubscribe function. */
   on(
     event: "registered",
     callback: (plugin: Plugin<D, I>) => void | Promise<void>
@@ -256,11 +217,4 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
     };
   }
 
-  /** Unsubscribe from plugin events */
-  off(
-    event: keyof PluginRegistryEvents<D, I>,
-    callback: (...args: any[]) => void
-  ): void {
-    this.#events.off(event, callback);
-  }
 }

--- a/core/plugins/src/registry/registry.ts
+++ b/core/plugins/src/registry/registry.ts
@@ -22,9 +22,9 @@ const log = debug("patchwork:plugins");
  */
 export class PluginRegistry<D extends PluginDescription, I = any> {
   #plugins = new Map<string, Plugin<D, I>>();
-  #loadPromises = new Map<string, Promise<LoadedPlugin<D, I>>>();
+  #loadPromises = new Map<string, Promise<LoadedPlugin<D, I> | undefined>>();
   #events = new EventEmitter<PluginRegistryEvents<D, I>>();
-  loading = new Set<string>();
+  #loading = new Set<string>();
 
   /**
    * Register an plugin with this registry
@@ -76,75 +76,71 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
    * If shouldWait is true, will wait for the plugin to be registered if it isn't already
    */
   async load(id: string): Promise<LoadedPlugin<D, I> | undefined> {
-    // TODO: error handling?
     log(`load called for: ${id}`, {});
 
-    // Check if we already have a loaded plugin
-    const plugin = this.#plugins.get(id);
-    log(`Found existing plugin: ${id}`, {
-      hasPlugin: !!plugin,
-      isLoadable: plugin ? isLoadablePlugin<D, I>(plugin) : "N/A",
-    });
-
-    if (plugin && isLoadedPlugin<D, I>(plugin)) {
-      log(`Returning already loaded plugin: ${id}`);
-      return plugin;
-    }
-
-    // Get the plugin description
     const description = this.#plugins.get(id);
     if (!description) {
       log(`Plugin not registered: ${id}`);
       return undefined;
     }
 
-    // If the plugin is loadable, load it
-    if (isLoadablePlugin(description)) {
-      log(`Loading plugin implementation: ${id}`);
-      this.loading.add(id);
-      const loadPromise = description
-        .load()
-        .then((implementation) => {
-          log(`Successfully loaded implementation for: ${id}`, implementation);
-          // Merge the implementation with the plugin metadata to create a complete Plugin
-          // Omit the load method as it's no longer needed
-          const { load, ...descriptionWithoutLoad } = description;
-          if (!isPluginDescription<D>(descriptionWithoutLoad)) {
-            throw new Error("Invalid plugin description");
-          }
-          const plugin = {
-            ...descriptionWithoutLoad,
-            module: implementation,
-          };
-
-          // Store the loaded version
-          this.#plugins.set(description.id, plugin);
-          this.#loadPromises.delete(id);
-          this.loading.delete(id);
-
-          // Notify listeners that an plugin has been loaded
-          this.#events.emit("loaded", plugin);
-          this.#events.emit("changed");
-
-          return plugin;
-        })
-        .catch((error) => {
-          console.error(`Failed to load plugin implementation: ${id}`, error);
-          this.#loadPromises.delete(id);
-          this.loading.delete(id);
-          throw error;
-        });
-
-      // Store the promise so we don't load twice
-      this.#loadPromises.set(id, loadPromise);
-      return loadPromise;
-    }
-
     if (isLoadedPlugin<D, I>(description)) {
+      log(`Returning already loaded plugin: ${id}`);
       return description;
     }
 
-    throw new Error(`Plugin ${id} is not loadable`);
+    const existingPromise = this.#loadPromises.get(id);
+    if (existingPromise) {
+      log(`Returning in-flight load for: ${id}`);
+      return existingPromise;
+    }
+
+    if (!isLoadablePlugin(description)) {
+      throw new Error(`Plugin ${id} is not loadable`);
+    }
+
+    log(`Loading plugin implementation: ${id}`);
+    this.#loading.add(id);
+
+    const loadPromise = description
+      .load()
+      .then((implementation) => {
+        // If the plugin was removed or re-registered while loading, discard
+        if (this.#plugins.get(id) !== description) {
+          log(`Plugin ${id} was replaced or removed during load, discarding`);
+          this.#loadPromises.delete(id);
+          this.#loading.delete(id);
+          return undefined;
+        }
+
+        log(`Successfully loaded implementation for: ${id}`, implementation);
+        const { load, ...descriptionWithoutLoad } = description;
+        if (!isPluginDescription<D>(descriptionWithoutLoad)) {
+          throw new Error("Invalid plugin description");
+        }
+        const plugin = {
+          ...descriptionWithoutLoad,
+          module: implementation,
+        };
+
+        this.#plugins.set(id, plugin);
+        this.#loadPromises.delete(id);
+        this.#loading.delete(id);
+
+        this.#events.emit("loaded", plugin);
+        this.#events.emit("changed");
+
+        return plugin;
+      })
+      .catch((error) => {
+        console.error(`Failed to load plugin implementation: ${id}`, error);
+        this.#loadPromises.delete(id);
+        this.#loading.delete(id);
+        throw error;
+      });
+
+    this.#loadPromises.set(id, loadPromise);
+    return loadPromise;
   }
 
   /**
@@ -175,12 +171,19 @@ export class PluginRegistry<D extends PluginDescription, I = any> {
 
     this.#plugins.delete(id);
     this.#loadPromises.delete(id);
-    this.loading.delete(id);
+    this.#loading.delete(id);
 
     this.#events.emit("removed", id);
     this.#events.emit("changed");
 
     return true;
+  }
+
+  /**
+   * Check if a plugin is currently being loaded
+   */
+  isLoading(id: string): boolean {
+    return this.#loading.has(id);
   }
 
   /**

--- a/tools/tiny-patchwork/module-settings-manager/src/module-settings/module-settings.tsx
+++ b/tools/tiny-patchwork/module-settings-manager/src/module-settings/module-settings.tsx
@@ -8,6 +8,7 @@ import { ModuleFilters, ModuleTable } from "./components";
 import { useModulePlugins } from "./hooks/useModulePlugins.ts";
 import { MODULE_FETCH_DEBOUNCE } from "./constants.ts";
 import { DebugToggle } from "./components/DebugToggle.tsx";
+import { unregisterPlugins } from "@inkandswitch/patchwork-plugins";
 
 export function ModuleSettings(props: PatchworkToolProps<ModuleSettingsDoc>) {
   const [searchInputValue, setSearchInputValue] = createSignal("");
@@ -55,6 +56,7 @@ export function ModuleSettings(props: PatchworkToolProps<ModuleSettingsDoc>) {
   };
 
   const handleRemoveModule = (url: AutomergeUrl) => {
+    unregisterPlugins(url);
     props.handle.change((doc) => {
       const idx = doc.modules.indexOf(url);
       if (idx !== -1) {


### PR DESCRIPTION
## Changes

- Added `PluginRegistry.remove(id)` and `unregisterPlugins(importUrl)`
- Module settings manager now unregisters plugins on remove
- Replaced `Promise.all` + try/catch with `Promise.allSettled` in `loadAll`
- Removed unused `off()` method from `PluginRegistry` in favor of returned unsub func we already use everywhere
- `load()` now deduplicates concurrent calls via `#loadPromises` check
- `load()` `.then()` handler discards result if plugin was removed or re-registered during load
- `setDocWatcher` deduplicates via `#watchedModules` Set, added null-safe `handle.doc()?.` access
- Removed dead code in `isPlugin` guard
- Made `loading` set private, added `isLoading(id)` accessor
- Fixed `attributeChangedCallback` — `toolId` and `docUrl` changes both use `old === val` early return, set private fields directly
- Non-function cleanup from tool render no longer added to `#teardowns`
- Added null-safe `doc?.["@patchwork"]` in `loadSuggestedImportUrl`

## Notes

**Removing `migrate()` is a breaking change** for any plugin packages still using `"patchwork:dataType"` (capital T) or `"supportedDataTypes"`. They would silently register into the wrong registry or fail to match any document type. Worth checking no deployed packages still use the old casing.

**`unregisterPlugins` may not match hot-reloaded plugins.** After a hot-reload, `ModuleWatcher` re-announces with a versioned URL, so the plugin's `importUrl` in the registry can differ from the original settings-doc URL. Clicking remove in the settings manager would update the Automerge doc correctly (so the plugin won't return on next load), but the in-memory registry entry would persist until page reload. Not data corruption, just stale until refresh.

**`patchwork-view` no longer re-inits on same-value attribute sets.** The `attributeChangedCallback` now early-returns when `old === val`. If anything relied on `setAttribute("doc-url", sameUrl)` to force a re-render, that would stop working.

**`toolId` changes now actually trigger teardown+init.** Previously, setting `toolId` via the property setter or attribute never triggered a re-render due to a check ordering bug. This is now fixed.

## Known existing issues not addressed in this PR

- **Concurrent teardown/init race.** Rapid attribute changes on `patchwork-view` can interleave two async teardown→init chains. 

- **`getSupportedToolsForType` unsound cast.** Returns `Plugin[]` (loaded or unloaded) but casts to `LoadedTool[]`. Callers accessing `.module` on unloaded plugins get `undefined`.
