### PR TITLE
Support dev mode for tool development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ dummy-non-existing-folder/
 **/.pnpm-store/
 .claude/
 .pushwork/
+sites/tiny-patchwork/dev-tools.json
 dist/

--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ pnpm install
 pnpm build
 SITE=tiny-patchwork pnpm dev
 ```
+
+## Dev mode for tools
+
+To develop core tools (e.g., the sideboard) and test them locally in Tiny Patchwork without affecting other users:
+
+1. In the tool directories, run `pushwork --dev init` then `pushwork --dev sync` (or `pushwork --dev watch`).
+2. In the root directory, run `pnpm tiny-dev-overrides` to automatically find all tools with dev versions and create a local dev override config. This scans for tools that have both a `pushwork.url` in their `package.json` (prod URL) and a `.pushwork/local-dev/snapshot.json` (dev URL).
+3. Start TPW with `DEV_TOOLS=1 SITE=tiny-patchwork pnpm dev`.

--- a/core/filesystem/src/module-watcher.ts
+++ b/core/filesystem/src/module-watcher.ts
@@ -28,17 +28,20 @@ export class ModuleWatcher {
   handles: DocHandle<ModuleSettingsDoc>[] | undefined;
   doneLoading: Promise<void>;
   #watchedModules = new Set<string>();
+  #overrides: Record<string, string>;
 
   onLoad: (name: string, mod: any) => void;
 
   constructor(
     repo: Repo,
     urls: AutomergeUrl | AutomergeUrl[],
-    callback: (name: string, mod: any) => void
+    callback: (name: string, mod: any) => void,
+    overrides: Record<string, string> = {}
   ) {
     this.repo = repo;
     this.urls = Array.isArray(urls) ? urls : [urls];
     this.onLoad = callback;
+    this.#overrides = overrides;
     this.doneLoading = this.init();
   }
 
@@ -139,7 +142,9 @@ export class ModuleWatcher {
     const promises = this.handles.map((handle) => {
       const doc = handle.doc();
       const { modules = [] } = doc;
-      return this.loadModules(modules);
+      // Apply dev overrides: substitute production URLs with dev URLs
+      const resolved = modules.map(m => (this.#overrides[m] ?? m) as string);
+      return this.loadModules(resolved);
     });
     await Promise.all(promises);
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview": "pnpm --filter gaios preview",
     "publish-packages": "pnpm -r publish --access=public",
     "test": "pnpm --filter \"./os\" test",
+    "tiny-dev-overrides": "node scripts/dev-overrides.mjs . > sites/tiny-patchwork/dev-tools.json.tmp && node -e 'JSON.parse(require(\"fs\").readFileSync(\"sites/tiny-patchwork/dev-tools.json.tmp\",\"utf8\"))' && mv sites/tiny-patchwork/dev-tools.json.tmp sites/tiny-patchwork/dev-tools.json || { echo 'tiny-dev-overrides failed:'; cat sites/tiny-patchwork/dev-tools.json.tmp; rm -f sites/tiny-patchwork/dev-tools.json.tmp; exit 1; }",
     "tsc": "pnpm -r exec tsc"
   },
   "pnpm": {

--- a/scripts/dev-overrides.mjs
+++ b/scripts/dev-overrides.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+// Finds dev overrides by walking the repo for tool directories that have both:
+//   1. A package.json with a pushwork.url field (the prod URL)
+//   2. A .pushwork/local-dev/snapshot.json (the dev URL)
+// Outputs a dev-tools.json-compatible map of { overrides: { prodUrl: devUrl } }
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const SKIP = new Set(["node_modules", ".git", ".pushwork", "dist"]);
+
+async function exists(p) {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walk(dir, overrides) {
+  const pkgPath = join(dir, "package.json");
+  const devSnapshotPath = join(dir, ".pushwork", "local-dev", "snapshot.json");
+
+  if (await exists(pkgPath) && await exists(devSnapshotPath)) {
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
+      const devSnapshot = JSON.parse(await readFile(devSnapshotPath, "utf-8"));
+      const prodUrl = pkg.pushwork?.url;
+      const devUrl = devSnapshot.rootDirectoryUrl;
+      if (prodUrl && devUrl) {
+        overrides[prodUrl] = devUrl;
+      }
+    } catch {}
+  }
+
+  let entries;
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP.has(entry)) continue;
+    const entryPath = join(dir, entry);
+    try {
+      const s = await stat(entryPath);
+      if (s.isDirectory()) await walk(entryPath, overrides);
+    } catch {}
+  }
+}
+
+const root = resolve(process.argv[2] || ".");
+const overrides = {};
+await walk(root, overrides);
+
+if (Object.keys(overrides).length === 0) {
+  console.error("No dev overrides found");
+  process.exit(0);
+}
+
+console.log(JSON.stringify({ overrides }, null, 2));

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -115,10 +115,19 @@ function onModuleLoaded(name: string, mod: any) {
   }
 }
 
+// Dev tool overrides: injected at build time from dev-tools.json (if present).
+// Maps production Automerge URLs to dev URLs for local tool development.
+declare const __DEV_TOOLS__: { overrides: Record<string, string> };
+const devOverrides = __DEV_TOOLS__.overrides;
+if (Object.keys(devOverrides).length > 0) {
+  console.log("[dev mode] Active tool overrides:", devOverrides);
+}
+
 const moduleWatcher = new ModuleWatcher(
   repo,
   [defaultToolsUrl, accountDocHandle.doc().moduleSettingsUrl],
-  onModuleLoaded
+  onModuleLoaded,
+  devOverrides
 );
 
 window.patchwork = { repo, modules: moduleWatcher, plugins, accountDocHandle };

--- a/sites/tiny-patchwork/vite.config.ts
+++ b/sites/tiny-patchwork/vite.config.ts
@@ -2,6 +2,15 @@ import { defineConfig } from "vite";
 import wasm from "vite-plugin-wasm";
 import patchwork from "@inkandswitch/patchwork-bootloader/vite";
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const devToolsPath = resolve(__dirname, "dev-tools.json");
+const devToolsConfig = process.env.DEV_TOOLS && existsSync(devToolsPath)
+  ? readFileSync(devToolsPath, "utf-8")
+  : '{"overrides":{}}';
 
 export default defineConfig({
   plugins: [
@@ -31,6 +40,9 @@ export default defineConfig({
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "credentialless",
     },
+  },
+  define: {
+    __DEV_TOOLS__: devToolsConfig,
   },
   build: {
     target: "firefox137",


### PR DESCRIPTION
This is a speculative PR introducing one idea for how to improve the local dev experience for core patchwork tools like the sideboard (it's an approach I've been using locally). Taking advantage of the functionality added to `pushwork` in https://github.com/inkandswitch/pushwork/pull/14, this allows you to run Tiny Patchwork in a dev tools mode where you can configure URL overrides for tools you're developing. 