### PR TITLE
Add dev-swap tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2089,6 +2089,49 @@ importers:
         specifier: ^8.45.0
         version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
 
+  tools/tiny-patchwork/dev-swap:
+    dependencies:
+      '@automerge/automerge-repo':
+        specifier: 2.5.3
+        version: 2.5.3
+      '@automerge/automerge-repo-react-hooks':
+        specifier: 'catalog:'
+        version: 2.5.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@inkandswitch/patchwork-filesystem':
+        specifier: workspace:^
+        version: link:../../../core/filesystem
+      '@inkandswitch/patchwork-plugins':
+        specifier: workspace:^
+        version: link:../../../core/plugins
+      '@inkandswitch/patchwork-react':
+        specifier: workspace:^
+        version: link:../../../packages/react
+      react:
+        specifier: ^18.0.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.0.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@inkandswitch/patchwork-bootloader':
+        specifier: workspace:^
+        version: link:../../../core/bootloader
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.1
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.1.4(vite@7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
+      vite:
+        specifier: ^7.1.9
+        version: 7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)
+      vite-plugin-css-injected-by-js:
+        specifier: ^3.5.2
+        version: 3.5.2(vite@7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))
+
   tools/tiny-patchwork/frame-configurator:
     dependencies:
       '@automerge/automerge':
@@ -11494,6 +11537,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -13651,6 +13706,10 @@ snapshots:
   vite-plugin-css-injected-by-js@3.5.2(vite@7.2.6(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)):
     dependencies:
       vite: 7.2.6(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)
+
+  vite-plugin-css-injected-by-js@3.5.2(vite@7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)):
+    dependencies:
+      vite: 7.3.1(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)
 
   vite-plugin-css-injected-by-js@3.5.2(vite@8.0.0(@types/node@24.9.1)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)):
     dependencies:

--- a/tools/tiny-patchwork/dev-swap/.gitignore
+++ b/tools/tiny-patchwork/dev-swap/.gitignore
@@ -1,0 +1,3 @@
+.pushwork/
+dist/
+node_modules/

--- a/tools/tiny-patchwork/dev-swap/README.md
+++ b/tools/tiny-patchwork/dev-swap/README.md
@@ -1,0 +1,82 @@
+# Dev Swap
+
+A patchwork tool for swapping production tools with dev versions on deployed TPW.
+
+## Setup
+
+1. Build and push the dev-swap tool:
+
+```bash
+cd tools/tiny-patchwork/dev-swap
+pnpm build
+pushwork sync
+```
+
+2. Install the tool on TPW. Either paste the pushwork URL into the Packages panel, or from the browser console:
+
+```js
+$command.installModule("automerge:<dev-swap-pushwork-url>")
+```
+
+3. Add it to your context tools via the Frame Configurator, or from the console:
+
+```js
+accountDocHandle.change(doc => {
+  doc.contextToolIds.push("dev-swap");
+});
+```
+
+The Dev Swap panel will appear in the right sidebar.
+
+## Usage
+
+### Developing a tool
+
+1. Set up a dev pushwork config for the tool you want to modify:
+
+```bash
+cd tools/sidebars/sideboard
+pushwork --dev test init
+```
+
+2. Make your changes to the tool source. Keep the plugin ID the same: dev-swap handles the renaming automatically.
+
+3. Build and push the dev version:
+
+```bash
+pushwork --dev test sync
+```
+
+Note the automerge URL printed by pushwork.
+
+4. In TPW, enter the dev URL in the Dev Swap panel input and click Swap (or use the console):
+
+```js
+devSwap("automerge:<dev-url>")
+```
+
+This will:
+- Load the dev module and register plugins with `-dev` suffixed IDs
+- For tools referenced in the account doc (sideboard, context sidebar, etc.): swap the account doc field to point to the `-dev` version
+- For tools not in the account doc (account picker, etc.): override the production plugin in the registry directly
+- Set up a folder doc watcher for hot reload
+
+5. Iterate: edit source, `pushwork --dev test sync`, and the tool hot-reloads automatically.
+
+6. When done, click Unswap in the panel or:
+
+```js
+devUnswap("automerge:<dev-url>")
+```
+
+This restores the original tool but keeps the dev URL in the panel so you can re-swap later with one click. To remove it from the panel entirely, click the x button and confirm.
+
+### Persistence
+
+Active swaps are stored in localStorage and restored on tool load (before the frame renders). The account doc retains the swapped tool IDs via Automerge, so swaps survive page reloads as long as the dev-swap tool is installed.
+
+Dev modules are not added to moduleSettings: they are loaded exclusively by the dev-swap engine to avoid ID conflicts with production tools.
+
+### Multiple swaps
+
+You can swap multiple tools at once. Each dev URL gets its own entry in the panel. If you swap a second dev URL for the same tool, the previous swap is cleaned up automatically while preserving the original tool ID for unswap.

--- a/tools/tiny-patchwork/dev-swap/package.json
+++ b/tools/tiny-patchwork/dev-swap/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@tiny-patchwork/dev-swap",
+  "type": "module",
+  "private": true,
+  "main": "./dist/index.js",
+  "pushwork": {
+    "url": "automerge:3rfYU4gVPjCbqKGRS6Z5yGNfcXBJ"
+  },
+  "scripts": {
+    "dev": "vite build --watch",
+    "build": "vite build",
+    "sync": "vite build && pushwork sync"
+  },
+  "dependencies": {
+    "@automerge/automerge-repo": "catalog:",
+    "@automerge/automerge-repo-react-hooks": "catalog:",
+    "@inkandswitch/patchwork-filesystem": "workspace:^",
+    "@inkandswitch/patchwork-plugins": "workspace:^",
+    "@inkandswitch/patchwork-react": "workspace:^",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "@inkandswitch/patchwork-bootloader": "workspace:^",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "vite": "^7.1.9",
+    "vite-plugin-css-injected-by-js": "^3.5.2",
+    "@vitejs/plugin-react": "^5.0.4"
+  }
+}

--- a/tools/tiny-patchwork/dev-swap/src/DevSwapPanel.tsx
+++ b/tools/tiny-patchwork/dev-swap/src/DevSwapPanel.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { AutomergeUrl, DocHandle } from "@automerge/automerge-repo";
+import type { ToolElement } from "@inkandswitch/patchwork-plugins";
+import {
+  devSwap,
+  devUnswap,
+  devRemove,
+  restoreDevSwaps,
+  loadDevSwaps,
+  type DevSwapState,
+} from "./dev-swap-engine";
+
+const btnStyle: React.CSSProperties = {
+  padding: "2px 8px",
+  borderRadius: "3px",
+  border: "none",
+  background: "#555",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "11px",
+};
+
+export function DevSwapPanel({
+  docUrl,
+  element,
+}: {
+  docUrl: AutomergeUrl;
+  element: ToolElement;
+}) {
+  const repo = element.repo;
+  const handleRef = useRef<DocHandle<any> | null>(null);
+  const [swaps, setSwaps] = useState<DevSwapState>({});
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState<string | null>(null);
+
+  const refresh = () => setSwaps(loadDevSwaps());
+
+  // Resolve handle and restore swaps on mount + expose on window.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    let cancelled = false;
+    repo.find(docUrl).then((handle: any) => {
+      if (cancelled) return;
+      handleRef.current = handle;
+      setReady(true);
+
+      restoreDevSwaps(repo, handle, refresh).then(setSwaps);
+
+      (window as any).devSwap = (url: AutomergeUrl) =>
+        devSwap(repo, handle, url, refresh).then(setSwaps);
+      (window as any).devUnswap = (url: AutomergeUrl) =>
+        devUnswap(handle, url).then(setSwaps);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSwap = useCallback(async (url?: AutomergeUrl) => {
+    const target = url || input.trim() as AutomergeUrl;
+    if (!target || !handleRef.current) return;
+    setError(null);
+    setLoading(true);
+    try {
+      const updated = await devSwap(repo, handleRef.current, target, refresh);
+      setSwaps(updated);
+      if (!url) setInput("");
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [input, repo]);
+
+  const handleUnswap = useCallback(
+    async (devUrl: AutomergeUrl) => {
+      if (!handleRef.current) return;
+      setError(null);
+      try {
+        setSwaps(await devUnswap(handleRef.current, devUrl));
+      } catch (e: any) {
+        setError(e.message);
+      }
+    },
+    []
+  );
+
+  const handleRemove = useCallback(
+    async (devUrl: AutomergeUrl) => {
+      if (!handleRef.current) return;
+      setError(null);
+      try {
+        setSwaps(await devRemove(handleRef.current, devUrl));
+        setConfirmingRemove(null);
+      } catch (e: any) {
+        setError(e.message);
+      }
+    },
+    []
+  );
+
+  if (!ready) {
+    return <div style={{ padding: "12px", fontSize: "13px" }}>Loading...</div>;
+  }
+
+  const entries = Object.values(swaps).sort((a, b) => {
+    const aId = a.entries[0]?.originalToolId ?? a.devUrl;
+    const bId = b.entries[0]?.originalToolId ?? b.devUrl;
+    return aId.localeCompare(bId);
+  });
+
+  return (
+    <div style={{ padding: "12px", fontFamily: "system-ui", fontSize: "13px" }}>
+      <h3 style={{ margin: "0 0 8px", fontSize: "14px" }}>Dev Swap</h3>
+
+      <div style={{ display: "flex", gap: "4px", marginBottom: "8px" }}>
+        <input
+          type="text"
+          placeholder="automerge:..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleSwap()}
+          style={{
+            flex: 1,
+            padding: "4px 8px",
+            border: "1px solid #666",
+            borderRadius: "4px",
+            fontSize: "12px",
+            fontFamily: "monospace",
+            background: "#333",
+            color: "#fff",
+          }}
+        />
+        <button
+          onClick={() => handleSwap()}
+          disabled={loading || !input.trim()}
+          style={{
+            ...btnStyle,
+            padding: "4px 10px",
+            fontSize: "12px",
+            opacity: loading || !input.trim() ? 0.5 : 1,
+            cursor: loading ? "wait" : "pointer",
+          }}
+        >
+          {loading ? "..." : "Swap"}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            color: "#f66",
+            fontSize: "12px",
+            marginBottom: "8px",
+            wordBreak: "break-all",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div style={{ color: "#888", fontSize: "12px" }}>
+          No active dev swaps.
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          {entries.map((record) => (
+            <div
+              key={record.devUrl}
+              style={{
+                padding: "6px 8px",
+                background: "#2a2a2a",
+                borderRadius: "4px",
+                fontSize: "12px",
+                border: record.swapped ? "1px solid #4a4" : "1px solid #444",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  marginBottom: "4px",
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: "monospace",
+                    fontSize: "11px",
+                    color: "#999",
+                    wordBreak: "break-all",
+                    flex: 1,
+                  }}
+                >
+                  {record.devUrl}
+                </div>
+                {confirmingRemove === record.devUrl ? (
+                  <div style={{ display: "flex", gap: "4px", marginLeft: "8px", flexShrink: 0 }}>
+                    <button
+                      onClick={() => handleRemove(record.devUrl)}
+                      style={{ ...btnStyle, background: "#a33" }}
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      onClick={() => setConfirmingRemove(null)}
+                      style={btnStyle}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setConfirmingRemove(record.devUrl)}
+                    style={{
+                      ...btnStyle,
+                      background: "transparent",
+                      color: "#888",
+                      padding: "0 4px",
+                      fontSize: "14px",
+                      lineHeight: "1",
+                      marginLeft: "8px",
+                      flexShrink: 0,
+                    }}
+                    title="Remove"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+              {record.entries.map((entry) => (
+                <div key={entry.originalToolId} style={{ marginBottom: "2px" }}>
+                  <span style={{ color: "#aaa" }}>{entry.originalToolId}</span>
+                  {" → "}
+                  <span style={{ fontWeight: 500, color: "#ddd" }}>{entry.devToolId}</span>
+                  <span style={{ color: "#888", marginLeft: "4px" }}>
+                    ({entry.field})
+                  </span>
+                </div>
+              ))}
+              <div style={{ marginTop: "4px" }}>
+                {record.swapped ? (
+                  <button
+                    onClick={() => handleUnswap(record.devUrl)}
+                    style={btnStyle}
+                  >
+                    Unswap
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => handleSwap(record.devUrl)}
+                    style={{ ...btnStyle, background: "#4a4" }}
+                  >
+                    Swap
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/tiny-patchwork/dev-swap/src/dev-swap-engine.ts
+++ b/tools/tiny-patchwork/dev-swap/src/dev-swap-engine.ts
@@ -1,0 +1,424 @@
+import {
+  type AutomergeUrl,
+  type DocHandle,
+  type Repo,
+  isValidAutomergeUrl,
+} from "@automerge/automerge-repo";
+import {
+  getRegistry,
+  registerPlugins,
+  unregisterPlugins,
+} from "@inkandswitch/patchwork-plugins";
+import type { FolderDoc } from "@inkandswitch/patchwork-filesystem";
+import { importModuleFromFolderDocUrl } from "@inkandswitch/patchwork-filesystem";
+
+const DEV_SWAPS_KEY = "tinyPatchworkDevSwaps";
+
+export type DevSwapEntry = {
+  // Layout doc field that was swapped, or "" for direct registry overrides.
+  field: string;
+  originalToolId: string;
+  devToolId: string;
+  // For registry overrides (field === ""): the production plugin's importUrl
+  // so we can re-import and restore it on unswap.
+  originalImportUrl?: string;
+};
+
+export type DevSwapRecord = {
+  devUrl: AutomergeUrl;
+  entries: DevSwapEntry[];
+  swapped: boolean;
+};
+
+export type DevSwapState = Record<string, DevSwapRecord>;
+
+type LayoutDoc = {
+  frameToolId: string;
+  accountSidebarToolId: string;
+  contextSidebarToolId: string;
+  contextToolIds: string[];
+  documentToolbarToolIds: string[];
+  moduleSettingsUrl: AutomergeUrl;
+};
+
+const SINGLE_FIELDS = [
+  "frameToolId",
+  "accountSidebarToolId",
+  "contextSidebarToolId",
+] as const;
+
+const ARRAY_FIELDS = ["contextToolIds", "documentToolbarToolIds"] as const;
+
+function findToolField(
+  doc: LayoutDoc,
+  toolId: string
+): { field: string; isArray: boolean; index?: number } | null {
+  for (const field of SINGLE_FIELDS) {
+    if (doc[field] === toolId) return { field, isArray: false };
+  }
+  for (const field of ARRAY_FIELDS) {
+    const index = doc[field].indexOf(toolId);
+    if (index !== -1) return { field, isArray: true, index };
+  }
+  return null;
+}
+
+// Clone a plugin with a -dev suffix. Idempotent: strips any existing -dev
+// before appending. Cloning avoids mutating cached import() objects.
+const patchDevId = (p: any) => ({
+  ...p,
+  id: p.id.replace(/-dev$/, "") + "-dev",
+});
+
+export function loadDevSwaps(): DevSwapState {
+  try {
+    return JSON.parse(localStorage.getItem(DEV_SWAPS_KEY) || "{}");
+  } catch {
+    return {};
+  }
+}
+
+function saveDevSwaps(swaps: DevSwapState) {
+  localStorage.setItem(DEV_SWAPS_KEY, JSON.stringify(swaps));
+}
+
+// Force patchwork-view elements showing a tool to teardown and reinit.
+// Used after registry overrides where the "registered" event alone
+// doesn't trigger re-render for already-loaded plugins.
+function refreshViewsForTool(toolId: string) {
+  const views = document.querySelectorAll(
+    `patchwork-view[tool-id="${toolId}"]`
+  );
+  for (const view of views) {
+    view.removeAttribute("tool-id");
+    view.setAttribute("tool-id", toolId);
+  }
+}
+
+// Active folder doc watchers for hot reload, keyed by devUrl
+const watchers = new Map<string, () => void>();
+
+// Production plugin objects saved before override, keyed by original tool ID.
+// Used to restore on unswap without re-importing.
+const savedProductionPlugins = new Map<string, any>();
+
+async function loadAndRegisterDevModule(
+  repo: Repo,
+  devUrl: AutomergeUrl
+): Promise<string[]> {
+  // Use a versioned URL to bypass ES module cache
+  const handle = await repo.find<FolderDoc>(devUrl);
+  const versionedUrl = handle.view(handle.heads()).url;
+  const mod = await importModuleFromFolderDocUrl(versionedUrl);
+  if (!Array.isArray(mod.plugins)) {
+    throw new Error("Module does not export a plugins array");
+  }
+
+  const devPlugins = mod.plugins.map(patchDevId);
+  registerPlugins(devPlugins, devUrl);
+
+  return devPlugins.map((p: any) => p.id as string);
+}
+
+function setupHotReload(
+  repo: Repo,
+  devUrl: AutomergeUrl,
+  accountDocHandle: DocHandle<LayoutDoc>,
+  onReload?: () => void
+) {
+  // Clean up existing watcher
+  watchers.get(devUrl)?.();
+
+  repo.find<FolderDoc>(devUrl).then((handle) => {
+    let previousSyncAt = handle.doc()?.lastSyncAt || 0;
+
+    const onChange = async () => {
+      const lastSyncAt = handle.doc()?.lastSyncAt || 0;
+      if (lastSyncAt <= previousSyncAt) return;
+      previousSyncAt = lastSyncAt;
+
+      console.log(`[dev-swap] Hot reloading ${devUrl}`);
+      try {
+        unregisterPlugins(devUrl);
+        await loadAndRegisterDevModule(repo, devUrl);
+        onReload?.();
+      } catch (e) {
+        console.error("[dev-swap] Hot reload failed:", e);
+      }
+    };
+
+    handle.on("change", onChange);
+    watchers.set(devUrl, () => handle.off("change", onChange));
+  });
+}
+
+export async function devSwap(
+  repo: Repo,
+  accountDocHandle: DocHandle<LayoutDoc>,
+  devUrl: AutomergeUrl,
+  onReload?: () => void
+): Promise<DevSwapState> {
+  if (!isValidAutomergeUrl(devUrl)) throw new Error("Invalid Automerge URL");
+
+  const devToolIds = await loadAndRegisterDevModule(repo, devUrl);
+
+  const swaps = loadDevSwaps();
+  const existingByOriginalId = new Map(
+    Object.entries(swaps).flatMap(([url, record]) =>
+      record.entries.map(
+        (entry) =>
+          [entry.originalToolId, { devUrl: url, entry }] as const
+      )
+    )
+  );
+
+  const doc = accountDocHandle.doc();
+  const entries: DevSwapEntry[] = [];
+
+  // Three cases per dev tool ID:
+  // 1. A different devUrl already swapped this tool. Clean up the old swap.
+  // 2. Same devUrl re-swap (after unswap). Reuse the saved field mapping.
+  // 3. Fresh swap. Look up which account doc field holds the original tool.
+  for (const devToolId of devToolIds) {
+    const originalId = devToolId.replace(/-dev$/, "");
+    const existing = existingByOriginalId.get(originalId);
+
+    if (existing) {
+      entries.push({
+        field: existing.entry.field,
+        originalToolId: originalId,
+        devToolId,
+      });
+      if (existing.devUrl !== devUrl) {
+        // Case 1: different devUrl. Clean up old swap.
+        const oldRecord = swaps[existing.devUrl];
+        if (oldRecord) {
+          oldRecord.entries = oldRecord.entries.filter(
+            (e) => e.originalToolId !== originalId
+          );
+          if (oldRecord.entries.length === 0) {
+            unregisterPlugins(existing.devUrl);
+            watchers.get(existing.devUrl)?.();
+            watchers.delete(existing.devUrl);
+            delete swaps[existing.devUrl];
+          }
+        }
+      } else {
+        // Case 2: same URL re-swap. Remove old record, replaced below.
+        delete swaps[existing.devUrl];
+      }
+    } else {
+      // Case 3: fresh swap. Find the field holding the original (or dev) tool ID.
+      const match =
+        findToolField(doc, originalId) || findToolField(doc, devToolId);
+      if (match) {
+        entries.push({
+          field: match.field,
+          originalToolId: originalId,
+          devToolId,
+        });
+      } else {
+        // Case 4: tool not in layout doc: direct registry override.
+        // Save the production importUrl so we can restore on unswap.
+        const registry = getRegistry("patchwork:tool");
+        const prodPlugin = registry.get(originalId);
+        entries.push({
+          field: "",
+          originalToolId: originalId,
+          devToolId,
+          originalImportUrl: prodPlugin?.importUrl,
+        });
+      }
+    }
+  }
+
+  const fieldEntries = entries.filter((e) => e.field);
+  const overrideEntries = entries.filter((e) => !e.field);
+
+  // Swap account doc fields for tools referenced in the layout doc.
+  if (fieldEntries.length > 0) {
+    accountDocHandle.change((d) => {
+      for (const entry of fieldEntries) {
+        const current = (d as any)[entry.field];
+        if (Array.isArray(current)) {
+          const previousDevToolId =
+            existingByOriginalId.get(entry.originalToolId)?.entry.devToolId;
+          let idx = current.indexOf(entry.originalToolId);
+          if (idx === -1 && previousDevToolId) {
+            idx = current.indexOf(previousDevToolId);
+          }
+          if (idx !== -1) current[idx] = entry.devToolId;
+        } else {
+          (d as any)[entry.field] = entry.devToolId;
+        }
+      }
+    });
+  }
+
+  // For tools not in the layout doc, register the dev version under the
+  // original ID so any patchwork-view loading it gets the dev code.
+  // Save the production plugin first so we can restore on unswap.
+  for (const entry of overrideEntries) {
+    const registry = getRegistry("patchwork:tool");
+    if (!savedProductionPlugins.has(entry.originalToolId)) {
+      const prodPlugin = registry.get(entry.originalToolId);
+      if (prodPlugin) {
+        savedProductionPlugins.set(entry.originalToolId, prodPlugin);
+      }
+    }
+    const devPlugin = registry.get(entry.devToolId);
+    if (devPlugin) {
+      registerPlugins([{ ...devPlugin, id: entry.originalToolId }], devUrl);
+      refreshViewsForTool(entry.originalToolId);
+      console.log(
+        `[dev-swap] Overrode "${entry.originalToolId}" with dev version`
+      );
+    }
+  }
+
+  swaps[devUrl] = { devUrl, entries, swapped: true };
+  saveDevSwaps(swaps);
+
+  setupHotReload(repo, devUrl, accountDocHandle, onReload);
+
+  for (const entry of fieldEntries) {
+    console.log(
+      `[dev-swap] Swapped "${entry.originalToolId}" -> "${entry.devToolId}" in ${entry.field}`
+    );
+  }
+
+  return swaps;
+}
+
+export async function devUnswap(
+  accountDocHandle: DocHandle<LayoutDoc>,
+  devUrl: AutomergeUrl
+): Promise<DevSwapState> {
+  if (!isValidAutomergeUrl(devUrl)) throw new Error("Invalid Automerge URL");
+
+  const swaps = loadDevSwaps();
+  const record = swaps[devUrl];
+  if (!record) {
+    throw new Error(`No dev swap found for "${devUrl}"`);
+  }
+
+  const fieldEntries = record.entries.filter((e) => e.field);
+  const overrideEntries = record.entries.filter((e) => !e.field);
+
+  // Restore layout doc fields to original tool IDs.
+  if (fieldEntries.length > 0) {
+    accountDocHandle.change((d) => {
+      for (const entry of fieldEntries) {
+        const current = (d as any)[entry.field];
+        if (Array.isArray(current)) {
+          const idx = current.indexOf(entry.devToolId);
+          if (idx !== -1) current[idx] = entry.originalToolId;
+        } else if (current === entry.devToolId) {
+          (d as any)[entry.field] = entry.originalToolId;
+        }
+      }
+    });
+  }
+
+  // Restore production plugins for registry overrides.
+  for (const entry of overrideEntries) {
+    const saved = savedProductionPlugins.get(entry.originalToolId);
+    if (saved) {
+      const registry = getRegistry("patchwork:tool");
+      registry.register(saved, saved.importUrl);
+      console.log(
+        `[dev-swap] Restored production "${entry.originalToolId}"`
+      );
+    } else {
+      console.warn(
+        `[dev-swap] No saved production plugin for "${entry.originalToolId}", refresh to restore`
+      );
+    }
+    // Force any patchwork-view showing this tool to reinit with the
+    // restored plugin. The registry "registered" event alone doesn't
+    // trigger re-render for already-loaded plugins.
+    refreshViewsForTool(entry.originalToolId);
+  }
+
+  watchers.get(devUrl)?.();
+  watchers.delete(devUrl);
+
+  // Keep record but mark as unswapped so it can be re-swapped later
+  record.swapped = false;
+  saveDevSwaps(swaps);
+
+  for (const entry of record.entries) {
+    console.log(`[dev-swap] Unswapped "${entry.devToolId}"`);
+  }
+
+  return swaps;
+}
+
+export async function devRemove(
+  accountDocHandle: DocHandle<LayoutDoc>,
+  devUrl: AutomergeUrl
+): Promise<DevSwapState> {
+  if (!isValidAutomergeUrl(devUrl)) throw new Error("Invalid Automerge URL");
+
+  let swaps = loadDevSwaps();
+  const record = swaps[devUrl];
+  if (!record) {
+    throw new Error(`No dev swap found for "${devUrl}"`);
+  }
+
+  if (record.swapped) {
+    await devUnswap(accountDocHandle, devUrl);
+  }
+
+  swaps = loadDevSwaps();
+  delete swaps[devUrl];
+  saveDevSwaps(swaps);
+
+  for (const entry of record.entries) {
+    console.log(`[dev-swap] Removed "${entry.devToolId}" in ${entry.field}`);
+  }
+
+  return swaps;
+}
+
+export async function restoreDevSwaps(
+  repo: Repo,
+  accountDocHandle: DocHandle<LayoutDoc>,
+  onReload?: () => void
+): Promise<DevSwapState> {
+  const swaps = loadDevSwaps();
+  const records = Object.values(swaps);
+  if (records.length === 0) return swaps;
+
+  const results = await Promise.allSettled(
+    records.map(async (record) => {
+      unregisterPlugins(record.devUrl);
+      await loadAndRegisterDevModule(repo, record.devUrl);
+      setupHotReload(repo, record.devUrl, accountDocHandle, onReload);
+
+      // Re-apply registry overrides for swapped tools not in the layout doc.
+      if (record.swapped) {
+        const registry = getRegistry("patchwork:tool");
+        for (const entry of record.entries) {
+          if (!entry.field) {
+            const devPlugin = registry.get(entry.devToolId);
+            if (devPlugin) {
+              registerPlugins(
+                [{ ...devPlugin, id: entry.originalToolId }],
+                record.devUrl
+              );
+            }
+          }
+        }
+      }
+    })
+  );
+
+  for (const r of results) {
+    if (r.status === "rejected") {
+      console.warn("[dev-swap] Failed to restore swap:", r.reason);
+    }
+  }
+
+  return swaps;
+}

--- a/tools/tiny-patchwork/dev-swap/src/index.ts
+++ b/tools/tiny-patchwork/dev-swap/src/index.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from "@inkandswitch/patchwork-plugins";
+import { toolify } from "@inkandswitch/patchwork-react";
+
+export const plugins: Plugin<any>[] = [
+  {
+    type: "patchwork:tool",
+    id: "dev-swap",
+    name: "Dev Swap",
+    icon: "FlaskConical",
+    supportedDatatypes: ["account"],
+    tags: ["context-tool"],
+    async load() {
+      const { DevSwapPanel } = await import("./DevSwapPanel");
+      const { restoreDevSwaps, loadDevSwaps } = await import("./dev-swap-engine");
+
+      // Eagerly restore dev swaps on tool load, not panel mount.
+      // This ensures dev plugins are registered with -dev IDs before
+      // PatchworkFrame tries to render them.
+      const swaps = loadDevSwaps();
+      if (Object.keys(swaps).length > 0) {
+        if ((window as any).patchwork?.repo) {
+          const { repo, accountDocHandle } = (window as any).patchwork;
+          restoreDevSwaps(repo, accountDocHandle).catch(console.error);
+        } else {
+          console.warn("[dev-swap] window.patchwork not available, dev swaps will restore on panel mount");
+        }
+      }
+
+      return toolify(DevSwapPanel);
+    },
+  },
+];

--- a/tools/tiny-patchwork/dev-swap/tsconfig.json
+++ b/tools/tiny-patchwork/dev-swap/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tools/tiny-patchwork/dev-swap/vite.config.ts
+++ b/tools/tiny-patchwork/dev-swap/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
+import externals from "@inkandswitch/patchwork-bootloader/externals";
+
+export default defineConfig({
+  base: "./",
+  plugins: [react(), cssInjectedByJsPlugin()],
+
+  build: {
+    emptyOutDir: true,
+    rollupOptions: {
+      external: externals,
+      input: "./src/index.ts",
+      output: {
+        format: "es",
+        entryFileNames: "[name].js",
+        chunkFileNames: "assets/[name]-[hash].js",
+        assetFileNames: "assets/[name][extname]",
+      },
+      preserveEntrySignatures: "strict",
+    },
+  },
+});


### PR DESCRIPTION
Adds a tool for swapping in dev versions of Patchwork tools during testing and unswapping them when you're finished testing. Swap-related changes are local and fully reverted on unswap. When you add dev swap to context tools, it keeps track of development versions for you. This can be used in conjunction with development versions via pushwork (if https://github.com/inkandswitch/pushwork/pull/15 is merged).

Currently you would need to manually install this tool. I'm not sure if we'd want it to automatically be available for users to add to the context tools if they choose (in part, to make it easier to load it up in incognito testing browsers).