### PR TITLE
Keyhive integration

### DIFF
--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -47,6 +47,7 @@
     "@automerge/automerge-repo-network-websocket": "catalog:",
     "@automerge/automerge-repo-storage-indexeddb": "catalog:",
     "@automerge/vanillajs": "catalog:",
+    "@keyhive/keyhive": "catalog:",
     "@inkandswitch/patchwork-elements": "workspace:^",
     "@inkandswitch/patchwork-filesystem": "workspace:^",
     "@inkandswitch/patchwork-plugins": "workspace:^",

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -19,7 +19,7 @@ import {
   isValidAutomergeUrl,
   parseAutomergeUrl,
   stringifyAutomergeUrl,
-  type PeerId,
+  type AutomergeUrl,
 } from "@automerge/automerge-repo/slim";
 import { resolvePath } from "@inkandswitch/patchwork-filesystem";
 
@@ -27,8 +27,17 @@ import { resolvePath } from "@inkandswitch/patchwork-filesystem";
 import { IndexedDBStorageAdapter } from "@automerge/automerge-repo-storage-indexeddb";
 import { MessageChannelNetworkAdapter } from "@automerge/automerge-repo-network-messagechannel";
 import { WebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
+import {
+  initializeAutomergeRepoKeyhiveRust,
+  initKeyhiveWasm,
+  type AutomergeRepoKeyhiveRust,
+} from "@automerge/automerge-repo-keyhive";
+
+declare const __SITE_NAME__: string;
+declare const __KEYHIVE__: boolean;
 
 // TEMPORARY: enable debug npm module in SW context (no localStorage available)
+
 let cachename = "default";
 let debugging = false;
 const workerInstanceId = crypto.randomUUID();
@@ -64,6 +73,8 @@ const slog = SwLogger.open().then((logger) => {
   return logger;
 });
 
+const siteName = typeof __SITE_NAME__ !== "undefined" ? __SITE_NAME__ : "tiny-patchwork";
+
 const cacheableStatuses = [200, 203, 204, 206];
 
 function log(...args: any[]) {
@@ -95,11 +106,16 @@ self.addEventListener("activate", async () => {
   clients.claim();
 });
 
-let repoPromise: Promise<Repo> | null = null;
+let repoHivePromise: Promise<{
+  repo: Repo;
+  hive?: AutomergeRepoKeyhiveRust;
+}> | null = null;
 
-function getRepo() {
-  if (!repoPromise) {
-    const p: Promise<Repo> = (async () => {
+const useKeyhive = typeof __KEYHIVE__ !== "undefined" && __KEYHIVE__;
+
+function getRepoHive() {
+  if (!repoHivePromise) {
+    repoHivePromise = (async () => {
       const logger = await slog;
       logger.info("getRepo: starting");
 
@@ -112,51 +128,130 @@ function getRepo() {
       await initializeWasm(new Uint8Array(amWasmBuf));
       logger.info("wasm initialized");
 
-      const signer = await WebCryptoSigner.setup();
+      if (!useKeyhive) {
+        const signer = await WebCryptoSigner.setup();
+
+        const repo = new Repo({
+          storage: new IndexedDBStorageAdapter(),
+          signer,
+          peerId: ("service-worker-" +
+            Math.random().toString(36).slice(2)) as import("@automerge/automerge-repo/slim").PeerId,
+          async sharePolicy(peerId) {
+            return peerId.includes("storage-server");
+          },
+          enableRemoteHeadsGossiping: true,
+          subductionWebsocketEndpoints: SUBDUCTION_ENDPOINTS,
+        });
+
+        (self as any).repo = repo;
+        logger.info("repo constructed (no keyhive), waiting for network subsystem");
+
+        repo.networkSubsystem.whenReady().then(() => {
+          logger.info("repo network subsystem ready");
+        });
+
+        return { repo };
+      }
+
+      initKeyhiveWasm();
+      const keyhiveStorage = new IndexedDBStorageAdapter(
+        `${siteName}-keyhive`
+      );
+
+      // Keyhive bootstrap needs to run before Repo creation but
+      // the adapter needs the subduction instance from the Repo.
+      // A deferred promise breaks the cycle.
+      let resolveRepoSubduction!: (s: any) => void;
+      const repoSubductionPromise = new Promise((resolve) => {
+        resolveRepoSubduction = resolve;
+      });
+
+      // We use the Rust variant of Keyhive initialization to talk
+      // to the Rust keyhive-enabled subduction sync server.
+      const hive = await initializeAutomergeRepoKeyhiveRust({
+        storage: keyhiveStorage,
+        peerIdSuffix:
+          `${siteName}-worker` + Math.random().toString(36).slice(2),
+        subduction: repoSubductionPromise as any,
+        automaticArchiveIngestion: true,
+        cachingMode: "periodic",
+      });
+
+      const signer = await hive.constructSubductionSigner();
 
       const repo = new Repo({
         storage: new IndexedDBStorageAdapter(),
         signer,
-        peerId: ("service-worker-" +
-          (Math.random() * 10000).toString(36).slice(2)) as PeerId,
-        async sharePolicy(peerId) {
-          return peerId.includes("storage-server");
-        },
-        enableRemoteHeadsGossiping: true,
         subductionWebsocketEndpoints: SUBDUCTION_ENDPOINTS,
-        network: [new WebSocketClientAdapter("wss://sync3.automerge.org")],
+        peerId: hive.peerId,
+        enableRemoteHeadsGossiping: true,
+        idFactory: hive.idFactory,
+        //network: [new WebSocketClientAdapter("wss://sync3.automerge.org")],
       });
 
+      repo.subduction.then(resolveRepoSubduction);
+
+      hive.linkRepo(repo);
+
       (self as any).repo = repo;
+      (self as any).hive = hive;
       logger.info("repo constructed, waiting for network subsystem");
 
-      // Don't block getRepo() on whenReady() — the network subsystem starts
+      // Don't block getRepoHive() on whenReady() — the network subsystem starts
       // with only the subduction adapter, and the MessageChannel adapter is
-      // added later via connectPort (which awaits getRepo). Blocking here
+      // added later via connectPort (which awaits getRepoHive). Blocking here
       // would deadlock that path and starve the fetch handler.
       repo.networkSubsystem.whenReady().then(() => {
         logger.info("repo network subsystem ready");
       });
 
-      return repo;
+      hive.networkAdapter.whenReady().then(() => {
+        (hive.networkAdapter as any).syncKeyhive();
+      });
+
+      return { hive, repo };
     })();
     // If construction fails (e.g. wasm fetch errors out because the SW was
     // terminated mid-flight), don't permanently cache the rejection — clear
     // the slot so the next caller can retry from scratch.
-    p.catch(() => {
-      if (repoPromise === p) repoPromise = null;
+    repoHivePromise.catch(() => {
+      repoHivePromise = null;
     });
-    repoPromise = p;
   }
-  return repoPromise;
+  return repoHivePromise;
 }
 
 // Connect client MessagePorts to the repo for sync
 async function connectPort(port: MessagePort) {
-  const repo = await getRepo();
-  repo.networkSubsystem.addNetworkAdapter(
-    new MessageChannelNetworkAdapter(port, { useWeakRef: true })
-  );
+  const { hive, repo } = await getRepoHive();
+  const networkAdapter = new MessageChannelNetworkAdapter(port, { useWeakRef: true });
+
+  if (!hive) {
+    repo.networkSubsystem.addNetworkAdapter(networkAdapter);
+    return;
+  }
+
+  const onlyShareWithHardcodedServerPeerId = false;
+  const periodicallyRequestKeyhiveSync = false;
+  const keyhiveNetworkAdapter = hive.createKeyhiveNetworkAdapter(networkAdapter, onlyShareWithHardcodedServerPeerId, periodicallyRequestKeyhiveSync, 2000);
+
+  keyhiveNetworkAdapter.on("message", async (msg: any) => {
+    if ((msg.type === "sync" || msg.type === "request") && msg.documentId) {
+      const handle = repo.handles[msg.documentId];
+      if (!handle || handle.state === "unavailable") {
+        const url = `automerge:${msg.documentId}` as AutomergeUrl;
+        repo.findWithProgress(url);
+        repo.shareConfigChanged();
+      }
+    }
+  });
+
+  (keyhiveNetworkAdapter as any).on("ingest-remote", () => {
+    (hive.networkAdapter as any).syncKeyhive?.();
+    repo.shareConfigChanged();
+  });
+
+  repo.networkSubsystem.addNetworkAdapter(keyhiveNetworkAdapter);
 }
 
 self.addEventListener("message", async (event) => {
@@ -219,7 +314,7 @@ self.addEventListener("message", async (event) => {
 // ── Automerge URL resolution ───────────────────────────────────────────
 
 async function resolveAutomergeUrl(automergeURL: URL): Promise<Response> {
-  const repo = await getRepo();
+  const { repo } = await getRepoHive();
   const href = automergeURL.href;
   const [maybeAutomergeUrl, ...path] = href.split("/");
 
@@ -362,8 +457,13 @@ self.addEventListener("fetch", (fetchEvent: FetchEvent) => {
           error instanceof Error
             ? `${error.message}\n\n${error.stack}`
             : String(error);
-        console.error(
-          `service worker error resolving ${request.url}${specialURL ? ` (for: ${specialURL})` : ""}.\n${message}`
+        const logger = await slog;
+        logger.error(
+          `service worker error resolving ${request.url}${specialURL ? ` (for: ${specialURL})` : ""}`,
+          {
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          }
         );
         if (match) return match;
 

--- a/core/bootloader/src/site.ts
+++ b/core/bootloader/src/site.ts
@@ -28,9 +28,18 @@ import {
 } from "@automerge/vanillajs/slim";
 import * as Automerge from "@automerge/automerge/slim";
 import * as AutomergeRepo from "@automerge/automerge-repo/slim";
+import {
+  initKeyhiveWasm,
+  initializeAutomergeRepoKeyhive,
+  type AutomergeRepoKeyhive,
+} from "@automerge/automerge-repo-keyhive";
 // eslint-disable-next-line
 // @ts-ignore — initSync is a wasm-bindgen runtime helper not in the .d.ts
 import { initSync as initSubductionSync } from "@automerge/automerge-subduction/slim";
+
+declare const __SITE_NAME__: string;
+const siteName =
+  typeof __SITE_NAME__ !== "undefined" ? __SITE_NAME__ : "tiny-patchwork";
 
 import { ModuleWatcher } from "@inkandswitch/patchwork-filesystem";
 import {
@@ -64,6 +73,8 @@ declare global {
     Automerge: typeof import("@automerge/automerge");
     AutomergeRepo: typeof import("@automerge/automerge-repo");
     repo: Repo;
+    hive?: AutomergeRepoKeyhive;
+    getRepoChannel: () => MessagePort;
     patchwork: {
       repo: Repo;
       packages: ModuleWatcher;
@@ -120,6 +131,13 @@ export interface SiteConfig {
    * Ink & Switch's production Subduction storage.
    */
   remoteStorageIds?: StorageId[];
+
+  /**
+   * When true, initialize keyhive for access control.
+   * The Repo will use keyhive's network adapter, peerId, and idFactory
+   * instead of a sharePolicy.
+   */
+  keyhive?: boolean;
 }
 
 export interface BootResult {
@@ -158,34 +176,72 @@ export async function bootPatchworkSite(
   await initializeWasm(automergeWasm);
   initSubductionSync(subductionWasm);
 
-  const repo = new Repo({
-    storage: new IndexedDBStorageAdapter(),
-    async sharePolicy(peerId) {
-      return peerId.includes("service-worker");
-    },
-    enableRemoteHeadsGossiping: true,
-    peerId:
-      `${config.titleSuffix}-tab-${crypto.randomUUID()}` as AutomergeRepo.PeerId,
-  });
+  const sw = await setupServiceWorker();
+  if (!sw) throw new Error("Failed to set up service worker");
 
+  let hive: AutomergeRepoKeyhive | undefined;
+  if (config.keyhive) {
+    initKeyhiveWasm();
+
+    // Get the initial SW port via subscribeToRepoChannel, then pass it
+    // to keyhive init which wraps it in its own network adapter.
+    let resolvePort!: (port: MessagePort) => void;
+    const portPromise = new Promise<MessagePort>((r) => { resolvePort = r; });
+    sw.subscribeToRepoChannel((port) => { resolvePort(port); });
+    const swPort = await portPromise;
+
+    hive = await initializeAutomergeRepoKeyhive({
+      storage: new IndexedDBStorageAdapter(
+        `${siteName}-keyhive`
+      ),
+      peerIdSuffix:
+        siteName +
+        Math.random().toString(36).slice(2),
+      networkAdapter: new MessageChannelNetworkAdapter(swPort),
+      automaticArchiveIngestion: true,
+      cachingMode: "periodic",
+      onlyShareWithHardcodedServerPeerId: false,
+    });
+  }
+
+  const repo = hive
+    ? new Repo({
+        storage: new IndexedDBStorageAdapter(),
+        enableRemoteHeadsGossiping: true,
+        network: [hive.networkAdapter],
+        peerId: hive.peerId,
+        idFactory: hive.idFactory,
+      })
+    : new Repo({
+        storage: new IndexedDBStorageAdapter(),
+        async sharePolicy(peerId) {
+          return peerId.includes("service-worker");
+        },
+        enableRemoteHeadsGossiping: true,
+        peerId:
+          `${config.titleSuffix}-tab-${crypto.randomUUID()}` as AutomergeRepo.PeerId,
+      });
   repo.subscribeToRemotes(
     config.remoteStorageIds ?? [DEFAULT_REMOTE_STORAGE_ID]
   );
 
-  const sw = await setupServiceWorker();
-  if (!sw) throw new Error("Failed to set up service worker");
-  let activeServiceWorkerPort: MessagePort | undefined;
-  const connectServiceWorkerPort = async (port: MessagePort) => {
-    const previousPort = activeServiceWorkerPort;
-    activeServiceWorkerPort = port;
-    const net = new MessageChannelNetworkAdapter(port);
-    repo.networkSubsystem.addNetworkAdapter(net);
-    await net.whenReady();
-    previousPort?.close();
-  };
-  await sw.subscribeToRepoChannel(connectServiceWorkerPort);
+  if (hive) {
+    await repo.networkSubsystem.whenReady();
+    (hive.networkAdapter as any).syncKeyhive?.();
+  } else {
+    let activeServiceWorkerPort: MessagePort | undefined;
+    const connectServiceWorkerPort = async (port: MessagePort) => {
+      const previousPort = activeServiceWorkerPort;
+      activeServiceWorkerPort = port;
+      const net = new MessageChannelNetworkAdapter(port);
+      repo.networkSubsystem.addNetworkAdapter(net);
+      await net.whenReady();
+      previousPort?.close();
+    };
+    await sw.subscribeToRepoChannel(connectServiceWorkerPort);
+  }
 
-  installDevConsoleGlobals(repo);
+  installDevConsoleGlobals(repo, hive);
 
   registerRepoProviderElement(repo);
   registerFallbackProviderElement();
@@ -202,9 +258,7 @@ export async function bootPatchworkSite(
   fallbackProvider.appendChild(repoProvider);
   repoProvider.appendChild(rootElement);
 
-  // Registers `<patchwork-view>` and the `<patchwork-view-legacy>` it
-  // delegates to in one go.
-  registerPatchworkViewElement();
+  registerPatchworkViewElement(hive ? { hive } : {});
 
   // The watcher is started with the site's default-tools bundle alone so that
   // `resolveAccountHandle` below has something to await on (the `account`
@@ -219,6 +273,7 @@ export async function bootPatchworkSite(
 
   const accountDocHandle = await resolveAccountHandle(repo, {
     storageKey: config.accountStorageKey,
+    hive,
   });
 
   window.accountDocHandle = accountDocHandle;
@@ -270,10 +325,21 @@ function resolveDefaultModulesUrl(builtin: AutomergeUrl): AutomergeUrl {
   return builtin;
 }
 
-function installDevConsoleGlobals(repo: Repo): void {
+function installDevConsoleGlobals(
+  repo: Repo,
+  hive: AutomergeRepoKeyhive | undefined
+): void {
   window.repo = repo;
   window.Automerge = Automerge;
   window.AutomergeRepo = AutomergeRepo;
+  if (hive) {
+    window.hive = hive;
+  }
+  window.getRepoChannel = () => {
+    const { port1, port2 } = new MessageChannel();
+    navigator.serviceWorker.controller!.postMessage({ type: "port" }, [port2]);
+    return port1;
+  };
 }
 
 function onModuleLoaded(name: string, mod: any): void {

--- a/core/bootloader/src/vite/importmap-plugin.ts
+++ b/core/bootloader/src/vite/importmap-plugin.ts
@@ -45,12 +45,22 @@ export function importmap(options?: PatchworkVitePluginOptions): Plugin {
         });
       }
 
-      // Emit automerge wasm so the service worker can fetch it
-      const wasmPath = require.resolve("@automerge/automerge/automerge.wasm");
+      // Emit automerge, keyhive, and subduction wasm so the service worker can fetch them
+      const automergeWasmPath = require.resolve(
+        "@automerge/automerge/automerge.wasm"
+      );
       this.emitFile({
         type: "asset",
         fileName: "automerge.wasm",
-        source: readFileSync(wasmPath),
+        source: readFileSync(automergeWasmPath),
+      });
+      const keyhiveWasmPath = require.resolve(
+        "@keyhive/keyhive/keyhive_wasm.wasm"
+      );
+      this.emitFile({
+        type: "asset",
+        fileName: "keyhive_wasm.wasm",
+        source: readFileSync(keyhiveWasmPath),
       });
 
       // Emit subduction wasm so the service worker can fetch it

--- a/core/elements/src/legacy-impl.ts
+++ b/core/elements/src/legacy-impl.ts
@@ -17,7 +17,10 @@ import {
 } from "@inkandswitch/patchwork-plugins";
 import { request } from "@inkandswitch/patchwork-providers";
 import debug from "debug";
-import type { initializeAutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
+import {
+  docIdFromAutomergeUrl,
+  type initializeAutomergeRepoKeyhive,
+} from "@automerge/automerge-repo-keyhive";
 import { MountedEvent, NoToolEvent, UnmountedEvent } from "./events.js";
 
 const log = debug("patchwork:elements:legacy");
@@ -82,6 +85,10 @@ export class LegacyImpl {
   #capturedParent: Element | null = null;
   #fallbackId: string | undefined;
   #teardowns = new Set<() => unknown | Promise<void>>();
+  #keyhiveRetrySetup = false;
+  #handlingKeyhiveSync = false;
+  #pendingKeyhiveSync = false;
+  #unableNoAccess = false;
 
   constructor(element: HTMLElement, params: LegacyImplParams = {}) {
     this.#element = element as HostElement;
@@ -162,6 +169,50 @@ export class LegacyImpl {
 
     const epoch = ++this.#initEpoch;
     this.#state = State.initializing;
+
+    if (this.#element.hive && this.#docUrl) {
+      let isKeyhiveDoc = false;
+      try {
+        docIdFromAutomergeUrl(this.#docUrl);
+        isKeyhiveDoc = true;
+      } catch {
+        // Legacy (padded-zero) doc: skip keyhive gate
+      }
+
+      if (isKeyhiveDoc) {
+        const bestAccess = await this.#element.hive.bestAccessForDoc(
+          this.#element.hive.active.individual.id,
+          this.#docUrl
+        );
+        const accessLevel = bestAccess ? bestAccess.toString() : "None";
+
+        if (accessLevel === "None") {
+          this.#state = State.unable;
+          this.#unableNoAccess = true;
+
+          if (!this.#keyhiveRetrySetup) {
+            this.#keyhiveRetrySetup = true;
+            const onKeyhiveSync = () => this.#handleKeyhiveSync();
+            (this.#element.hive.networkAdapter as any).on("ingest-remote", onKeyhiveSync);
+            this.#teardowns.add(() => {
+              (this.#element.hive!.networkAdapter as any).off("ingest-remote", onKeyhiveSync);
+            });
+          }
+          return;
+        }
+      }
+
+      if (!this.#keyhiveRetrySetup) {
+        this.#keyhiveRetrySetup = true;
+        const onKeyhiveSync = () => this.#handleKeyhiveSync();
+        (this.#element.hive.networkAdapter as any).on("ingest-remote", onKeyhiveSync);
+        this.#teardowns.add(() => {
+          (this.#element.hive!.networkAdapter as any).off("ingest-remote", onKeyhiveSync);
+        });
+      }
+    }
+
+    if (epoch !== this.#initEpoch) return;
 
     const removeAddedListener = toolRegistry.on(
       "registered",
@@ -257,6 +308,8 @@ export class LegacyImpl {
     }
 
     this.#teardowns.clear();
+    this.#keyhiveRetrySetup = false;
+    this.#unableNoAccess = false;
     this.#handle = null;
     this.#tool = null;
     this.#requestedToolImports.clear();
@@ -280,6 +333,73 @@ export class LegacyImpl {
     let node: Element | null = this.#capturedParent;
     while (node && !node.isConnected) node = node.parentElement;
     if (node) node.dispatchEvent(event);
+  }
+
+  async #clearDocCache(): Promise<void> {
+    if (!this.#docUrl || !this.#element.repo) return;
+
+    const retryingDocs = (globalThis as any).__patchwork_retrying_docs ??= new Set<string>();
+    if (retryingDocs.has(this.#docUrl)) return;
+
+    retryingDocs.add(this.#docUrl);
+    try {
+      const documentId = String(docIdFromAutomergeUrl(this.#docUrl));
+      const handle = (this.#element.repo.handles as any)[documentId];
+      if (handle && handle.state === "unavailable") {
+        this.#element.repo.delete(this.#docUrl);
+      }
+    } catch {
+      // Ignore delete errors
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 300));
+    retryingDocs.delete(this.#docUrl);
+  }
+
+  async #handleKeyhiveSync(): Promise<void> {
+    if (!this.#docUrl || !this.#element.hive) return;
+
+    if (this.#handlingKeyhiveSync) {
+      this.#pendingKeyhiveSync = true;
+      return;
+    }
+    this.#handlingKeyhiveSync = true;
+    this.#pendingKeyhiveSync = false;
+
+    try {
+      let hasAccess = false;
+      let accessCheckSucceeded = false;
+      try {
+        docIdFromAutomergeUrl(this.#docUrl);
+        const bestAccess = await this.#element.hive.bestAccessForDoc(
+          this.#element.hive.active.individual.id,
+          this.#docUrl
+        );
+        hasAccess = !!bestAccess;
+        accessCheckSucceeded = true;
+      } catch {
+        return;
+      }
+
+      const isDisplayed =
+        this.#state === State.rendered || this.#state === State.fallback;
+      const isUnable = this.#state === State.unable;
+
+      if (hasAccess && isUnable && this.#unableNoAccess) {
+        await this.#clearDocCache();
+        await this.#teardown();
+        void this.#init();
+      } else if (!hasAccess && isDisplayed && accessCheckSucceeded) {
+        await this.#clearDocCache();
+        await this.#teardown();
+        void this.#init();
+      }
+    } finally {
+      this.#handlingKeyhiveSync = false;
+      if (this.#pendingKeyhiveSync) {
+        this.#handleKeyhiveSync();
+      }
+    }
   }
 
   #queueRender(): void {

--- a/core/elements/src/patchwork-view.ts
+++ b/core/elements/src/patchwork-view.ts
@@ -9,6 +9,7 @@ import {
 } from "@inkandswitch/patchwork-plugins";
 import { MountedEvent, UnmountedEvent } from "./events.js";
 import { LegacyImpl } from "./legacy-impl.js";
+import { docIdFromAutomergeUrl } from "@automerge/automerge-repo-keyhive";
 
 type AutomergeRepoKeyhive = Awaited<
   ReturnType<typeof initializeAutomergeRepoKeyhive>
@@ -90,6 +91,10 @@ export function registerPatchworkViewElement(
       #state: State = State.none;
       #initEpoch = 0;
       #teardowns = new Set<() => unknown | Promise<void>>();
+      #keyhiveRetrySetup = false;
+      #handlingKeyhiveSync = false;
+      #pendingKeyhiveSync = false;
+      #unableNoAccess = false;
 
       // In legacy mode, the legacy view logic is hosted on *this*
       // element (not a child) so events dispatched on `<patchwork-view>`
@@ -241,6 +246,62 @@ export function registerPatchworkViewElement(
         const epoch = ++this.#initEpoch;
         this.#state = State.initializing;
 
+        if (params.hive && this.url) {
+          let isKeyhiveDoc = false;
+          try {
+            docIdFromAutomergeUrl(this.url);
+            isKeyhiveDoc = true;
+          } catch {
+            // Legacy (padded-zero) doc: skip keyhive gate
+          }
+
+          if (isKeyhiveDoc) {
+            const bestAccess = await params.hive.bestAccessForDoc(
+              params.hive.active.individual.id,
+              this.url
+            );
+            const accessLevel = bestAccess ? bestAccess.toString() : "None";
+
+            if (accessLevel === "None") {
+              this.#state = State.unable;
+              this.#unableNoAccess = true;
+
+              if (!this.#keyhiveRetrySetup) {
+                this.#keyhiveRetrySetup = true;
+                const onKeyhiveSync = () => this.#handleKeyhiveSync();
+                (params.hive.networkAdapter as any).on(
+                  "ingest-remote",
+                  onKeyhiveSync
+                );
+                this.#teardowns.add(() => {
+                  (params.hive!.networkAdapter as any).off(
+                    "ingest-remote",
+                    onKeyhiveSync
+                  );
+                });
+              }
+              return;
+            }
+          }
+
+          if (!this.#keyhiveRetrySetup) {
+            this.#keyhiveRetrySetup = true;
+            const onKeyhiveSync = () => this.#handleKeyhiveSync();
+            (params.hive.networkAdapter as any).on(
+              "ingest-remote",
+              onKeyhiveSync
+            );
+            this.#teardowns.add(() => {
+              (params.hive!.networkAdapter as any).off(
+                "ingest-remote",
+                onKeyhiveSync
+              );
+            });
+          }
+        }
+
+        if (epoch !== this.#initEpoch) return;
+
         const removeAddedListener = registry.on("registered", async (added) => {
           if (added.id !== this.component) return;
           if (isLoadablePlugin(added)) {
@@ -295,6 +356,8 @@ export function registerPatchworkViewElement(
 
         this.#teardowns.clear();
         this.#loaded = null;
+        this.#keyhiveRetrySetup = false;
+        this.#unableNoAccess = false;
         this.#state = State.none;
 
         if (wasMounted && mountedComponentId) {
@@ -314,6 +377,49 @@ export function registerPatchworkViewElement(
         let node: Element | null = this.#capturedParent;
         while (node && !node.isConnected) node = node.parentElement;
         if (node) node.dispatchEvent(event);
+      }
+
+      async #handleKeyhiveSync() {
+        if (!this.url || !params.hive) return;
+
+        if (this.#handlingKeyhiveSync) {
+          this.#pendingKeyhiveSync = true;
+          return;
+        }
+        this.#handlingKeyhiveSync = true;
+        this.#pendingKeyhiveSync = false;
+
+        try {
+          let hasAccess = false;
+          let accessCheckSucceeded = false;
+          try {
+            docIdFromAutomergeUrl(this.url);
+            const bestAccess = await params.hive.bestAccessForDoc(
+              params.hive.active.individual.id,
+              this.url
+            );
+            hasAccess = !!bestAccess;
+            accessCheckSucceeded = true;
+          } catch {
+            return;
+          }
+
+          const isDisplayed = this.#state === State.rendered;
+          const isUnable = this.#state === State.unable;
+
+          if (hasAccess && isUnable && this.#unableNoAccess) {
+            await this.#teardown();
+            this.#sync();
+          } else if (!hasAccess && isDisplayed && accessCheckSucceeded) {
+            await this.#teardown();
+            this.#sync();
+          }
+        } finally {
+          this.#handlingKeyhiveSync = false;
+          if (this.#pendingKeyhiveSync) {
+            this.#handleKeyhiveSync();
+          }
+        }
       }
 
       #queueRender() {

--- a/core/plugins/src/account.ts
+++ b/core/plugins/src/account.ts
@@ -5,6 +5,7 @@ import {
   type Repo,
 } from "@automerge/automerge-repo";
 import type { HasPatchworkMetadata } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 import { getRegistry } from "./registry/index.js";
 import type { DatatypeDescription } from "./datatypes.js";
 import { createDocOfDatatype2 } from "./datatypes.js";
@@ -43,6 +44,7 @@ export async function resolveAccountHandle<D = AccountDoc>(
   repo: Repo,
   options: {
     storageKey: string;
+    hive?: AutomergeRepoKeyhive;
     storage?: Pick<Storage, "getItem" | "setItem">;
   }
 ): Promise<DocHandle<D & HasPatchworkMetadata>> {
@@ -60,9 +62,23 @@ export async function resolveAccountHandle<D = AccountDoc>(
     }
   }
 
+  const handle = await createAccount<D>(repo, options.hive);
+  storage.setItem(options.storageKey, handle.url);
+  return handle;
+}
+
+async function createAccount<D>(
+  repo: Repo,
+  hive: AutomergeRepoKeyhive | undefined,
+): Promise<DocHandle<D & HasPatchworkMetadata>> {
   const datatypes = getRegistry<DatatypeDescription>("patchwork:datatype");
   const accountDatatype = await datatypes.loadWhenReady("account");
-  const handle = await createDocOfDatatype2<D>(accountDatatype, repo);
-  storage.setItem(options.storageKey, handle.url);
-  return handle as DocHandle<D & HasPatchworkMetadata>;
+  const handle = await createDocOfDatatype2<D>(accountDatatype, repo, undefined, hive);
+
+  if (hive) {
+    await hive.addSyncServerRelayToDoc(handle.url);
+  }
+
+  return handle;
 }
+

--- a/core/plugins/src/datatypes.ts
+++ b/core/plugins/src/datatypes.ts
@@ -11,6 +11,7 @@ import type {
   PluginDescription,
 } from "./registry/types.js";
 import type { HasPatchworkMetadata } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeRepoKeyhive } from "@automerge/automerge-repo-keyhive";
 
 // Datatype implementation interface
 export type DatatypeImplementation<D = unknown> = {
@@ -42,9 +43,14 @@ export type LoadedDatatype<D = unknown> = LoadedPlugin<
 export const createDocOfDatatype2 = async <D>(
   datatype: LoadedDatatype<D>,
   repo: Repo,
-  change?: (doc: D) => void
+  change?: (doc: D) => void,
+  hive?: AutomergeRepoKeyhive
 ): Promise<DocHandle<D & HasPatchworkMetadata>> => {
   const handle = await repo.create2<D & HasPatchworkMetadata>();
+  // Add sync server with relay access
+  if (hive) {
+    await hive.addSyncServerRelayToDoc(handle.url);
+  }
   handle.change((doc) => {
     datatype.module.init(doc, repo);
     let importUrl = datatype.importUrl;
@@ -65,5 +71,6 @@ export const createDocOfDatatype2 = async <D>(
       change(doc);
     }
   });
+
   return handle;
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "overrides": {
       "@automerge/automerge": "catalog:",
       "@automerge/automerge-repo": "catalog:",
+      "@automerge/automerge-repo-keyhive": "catalog:",
       "@automerge/automerge-repo-network-messagechannel": "catalog:",
       "@automerge/automerge-repo-network-websocket": "catalog:",
       "@automerge/automerge-repo-react-hooks": "catalog:",
@@ -33,7 +34,8 @@
       "@automerge/automerge-repo-storage-indexeddb": "catalog:",
       "@automerge/automerge-subduction": "catalog:",
       "@automerge/react": "catalog:",
-      "@automerge/vanillajs": "catalog:"
+      "@automerge/vanillajs": "catalog:",
+      "@keyhive/keyhive": "catalog:"
     }
   },
   "keywords": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@automerge/automerge-repo-keyhive':
-      specifier: 0.2.0-alpha.1d
-      version: 0.2.0-alpha.1d
-    '@keyhive/keyhive':
-      specifier: 0.0.0-alpha.56
-      version: 0.0.0-alpha.56
     '@types/react':
       specifier: 18.3.1
       version: 18.3.1
@@ -28,14 +22,16 @@ catalogs:
 overrides:
   '@automerge/automerge': 3.3.0-fragments.1
   '@automerge/automerge-repo': 2.6.0-subduction.23
+  '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.1
   '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.23
   '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.23
   '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.23
   '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.23
   '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.23
-  '@automerge/automerge-subduction': 0.12.1
+  '@automerge/automerge-subduction': 0.13.0
   '@automerge/react': 2.6.0-subduction.23
   '@automerge/vanillajs': 2.6.0-subduction.23
+  '@keyhive/keyhive': 0.0.0-alpha.56
 
 importers:
 
@@ -52,8 +48,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@24.9.1)
@@ -100,8 +96,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
@@ -117,6 +113,9 @@ importers:
       '@inkandswitch/patchwork-providers':
         specifier: workspace:^
         version: link:../../packages/providers/core
+      '@keyhive/keyhive':
+        specifier: 0.0.0-alpha.56
+        version: 0.0.0-alpha.56
       '@types/debug':
         specifier: ^4.1.12
         version: 4.1.12
@@ -134,8 +133,8 @@ importers:
         version: 0.1.4
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       esbuild:
         specifier: ^0.23.1
         version: 0.23.1
@@ -153,8 +152,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -205,8 +204,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.22)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
@@ -236,8 +235,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@inkandswitch/patchwork-filesystem':
         specifier: workspace:^
         version: link:../filesystem
@@ -502,8 +501,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
@@ -533,8 +532,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -542,7 +541,7 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 'catalog:'
+        specifier: 0.0.0-alpha.56
         version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
@@ -587,8 +586,8 @@ importers:
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
       '@automerge/automerge-subduction':
-        specifier: 0.12.1
-        version: 0.12.1
+        specifier: 0.13.0
+        version: 0.13.0
       '@automerge/vanillajs':
         specifier: 2.6.0-subduction.23
         version: 2.6.0-subduction.23
@@ -618,8 +617,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@automerge/automerge-repo-keyhive':
-        specifier: 'catalog:'
-        version: 0.2.0-alpha.1d
+        specifier: 0.3.0-alpha.sub.1
+        version: 0.3.0-alpha.sub.1(ws@8.18.3)
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.38.0
@@ -627,7 +626,7 @@ importers:
         specifier: workspace:^
         version: link:../../core/bootloader
       '@keyhive/keyhive':
-        specifier: 'catalog:'
+        specifier: 0.0.0-alpha.56
         version: 0.0.0-alpha.56
       '@tailwindcss/vite':
         specifier: ^4.1.14
@@ -659,8 +658,8 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@automerge/automerge-repo-keyhive@0.2.0-alpha.1d':
-    resolution: {integrity: sha512-p+4PnUua9vtvmdoZQXNOdl6SJGISF90JHi95zw33gUen4LHerNgXx7RVc0uDMC6WOfhKxJANqE2f+VKCQwis9w==}
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1':
+    resolution: {integrity: sha512-ctbVNLketU4Z22Mc+o4MJtE4s6tIPGswO53uVweI8l5yFYYYfGORDEjwlgHHPgYT7whoRB7kNiY3X9F2bvVRjQ==}
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.23':
     resolution: {integrity: sha512-lCsxaauTmtd2bxwW2p5Kk6zRqjgxCOXUcMDb4T2Yb6GtT7jo6gbBZh5G9U4UPANwGICdyQGJREQh8bj5n6BMOw==}
@@ -689,8 +688,8 @@ packages:
   '@automerge/automerge-repo@2.6.0-subduction.23':
     resolution: {integrity: sha512-SziEXGS4LlKmR6DK8Zf9FM12j14E39NM9kbzLoKx6cKdjEqowUyxDSpPAFrUPjrmFQ8eLw3p8DMb18mtoZD80Q==}
 
-  '@automerge/automerge-subduction@0.12.1':
-    resolution: {integrity: sha512-s1s40RTozkqExIk1LYdogKPzpCMFfe/7KBS0ccAlwsy4JwdcUGG9NQO2Pm3kZq8vD3OPw7DcIOSPG+bnLESQFg==}
+  '@automerge/automerge-subduction@0.13.0':
+    resolution: {integrity: sha512-7XlCIS0GH3ctboE8UPmD9rfiv203Q8n5Lx63xE6xCgtlpwecDKqzLDp77e9hUEo76j17Y8bYQyfsROqaByLf5A==}
 
   '@automerge/automerge@3.3.0-fragments.1':
     resolution: {integrity: sha512-Im2n3qcYSuIsLDSjofTRo7CZyyvFn5pKLSCCO5sjWzESw+9q9G25ZIrL2mczDX43cXtyzi+w/4b9VUaiNdY56Q==}
@@ -702,33 +701,33 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
-    resolution: {integrity: sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==}
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
-    resolution: {integrity: sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==}
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
-    resolution: {integrity: sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==}
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
     cpu: [arm64]
     os: [linux]
 
-  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
-    resolution: {integrity: sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==}
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
     cpu: [arm]
     os: [linux]
 
-  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
-    resolution: {integrity: sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==}
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
     cpu: [x64]
     os: [linux]
 
-  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
-    resolution: {integrity: sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==}
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
     cpu: [x64]
     os: [win32]
 
@@ -2008,12 +2007,12 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  cbor-extract@2.2.0:
-    resolution: {integrity: sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==}
+  cbor-extract@2.2.2:
+    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
     hasBin: true
 
-  cbor-x@1.6.0:
-    resolution: {integrity: sha512-0kareyRwHSkL6ws5VXHEf8uY1liitysCVJjlmhaLG+IXLqhSaOO+t63coaso7yjwEzWZzLy8fJo06gZDVQM9Qg==}
+  cbor-x@1.6.4:
+    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -3382,8 +3381,8 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xstate@5.31.0:
-    resolution: {integrity: sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==}
+  xstate@5.32.0:
+    resolution: {integrity: sha512-zsk73aWGmxn9z34P0kbiod5JwTvdYRW3+IDxITq8sd9+VWwMyW7BUzpplnYy9mIEXa6V8IMDv7Hy4m0mhT5+2Q==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3411,17 +3410,20 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@automerge/automerge-repo-keyhive@0.2.0-alpha.1d':
+  '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.1(ws@8.18.3)':
     dependencies:
       '@automerge/automerge-repo': 2.6.0-subduction.23
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.23
+      '@automerge/automerge-subduction': 0.13.0
       '@keyhive/keyhive': 0.0.0-alpha.56
-      cbor-x: 1.6.0
+      cbor-x: 1.6.4
       eventemitter3: 5.0.1
+      isomorphic-ws: 5.0.0(ws@8.18.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+      - ws
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.23':
     dependencies:
@@ -3444,7 +3446,7 @@ snapshots:
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.23':
     dependencies:
       '@automerge/automerge-repo': 2.6.0-subduction.23
-      cbor-x: 1.6.0
+      cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.1
       isomorphic-ws: 5.0.0(ws@8.18.3)
@@ -3488,22 +3490,22 @@ snapshots:
   '@automerge/automerge-repo@2.6.0-subduction.23':
     dependencies:
       '@automerge/automerge': 3.3.0-fragments.1
-      '@automerge/automerge-subduction': 0.12.1
+      '@automerge/automerge-subduction': 0.13.0
       bs58check: 3.0.1
-      cbor-x: 1.6.0
+      cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.1
       fast-sha256: 1.3.0
       isomorphic-ws: 5.0.0(ws@8.18.3)
       uuid: 9.0.1
       ws: 8.18.3
-      xstate: 5.31.0
+      xstate: 5.32.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-subduction@0.12.1': {}
+  '@automerge/automerge-subduction@0.13.0': {}
 
   '@automerge/automerge@3.3.0-fragments.1': {}
 
@@ -3521,22 +3523,22 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
-  '@cbor-extract/cbor-extract-darwin-arm64@2.2.0':
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
     optional: true
 
-  '@cbor-extract/cbor-extract-darwin-x64@2.2.0':
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
     optional: true
 
-  '@cbor-extract/cbor-extract-linux-arm64@2.2.0':
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
     optional: true
 
-  '@cbor-extract/cbor-extract-linux-arm@2.2.0':
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
     optional: true
 
-  '@cbor-extract/cbor-extract-linux-x64@2.2.0':
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
     optional: true
 
-  '@cbor-extract/cbor-extract-win32-x64@2.2.0':
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
     optional: true
 
   '@changesets/apply-release-plan@7.0.14':
@@ -4609,21 +4611,21 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  cbor-extract@2.2.0:
+  cbor-extract@2.2.2:
     dependencies:
       node-gyp-build-optional-packages: 5.1.1
     optionalDependencies:
-      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.0
-      '@cbor-extract/cbor-extract-darwin-x64': 2.2.0
-      '@cbor-extract/cbor-extract-linux-arm': 2.2.0
-      '@cbor-extract/cbor-extract-linux-arm64': 2.2.0
-      '@cbor-extract/cbor-extract-linux-x64': 2.2.0
-      '@cbor-extract/cbor-extract-win32-x64': 2.2.0
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
     optional: true
 
-  cbor-x@1.6.0:
+  cbor-x@1.6.4:
     optionalDependencies:
-      cbor-extract: 2.2.0
+      cbor-extract: 2.2.2
 
   chai@5.3.3:
     dependencies:
@@ -6004,7 +6006,7 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  xstate@5.31.0: {}
+  xstate@5.32.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,13 @@ packages:
 catalog:
   "@automerge/automerge": 3.3.0-fragments.1
   "@automerge/automerge-repo": 2.6.0-subduction.23
-  "@automerge/automerge-repo-keyhive": 0.2.0-alpha.1d
+  "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.1
   "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.23
   "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.23
   "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.23
   "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.23
   "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.23
-  "@automerge/automerge-subduction": 0.12.1
+  "@automerge/automerge-subduction": 0.13.0
   "@automerge/react": 2.6.0-subduction.23
   "@automerge/vanillajs": 2.6.0-subduction.23
   "@keyhive/keyhive": 0.0.0-alpha.56

--- a/sites/gaios/src/main.ts
+++ b/sites/gaios/src/main.ts
@@ -1,7 +1,9 @@
 import "./global.css";
 
-import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
+declare const __KEYHIVE__: boolean;
+
 import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
 // Published tools are registered in this module-settings doc via
 // `pnpm register` from each tool's own repo (see patchwork-tools and
@@ -14,4 +16,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "gaiosAccountUrl",
   titleSuffix: "GAIOS",
+  keyhive: __KEYHIVE__,
 });

--- a/sites/gaios/vite.config.ts
+++ b/sites/gaios/vite.config.ts
@@ -20,6 +20,10 @@ const subductionDir = dirname(
 );
 
 export default defineConfig({
+  define: {
+    __SITE_NAME__: JSON.stringify("gaios"),
+    __KEYHIVE__: JSON.stringify(process.env.KEYHIVE === "true"),
+  },
   plugins: [
     tailwindcss(),
     wasm(),
@@ -29,6 +33,7 @@ export default defineConfig({
           DEV: "data:text/javascript,export%20const%20DEV%20=%20true;",
         },
       },
+      extraBuiltins: ["@automerge/automerge-repo-keyhive"],
     }),
   ],
   worker: {
@@ -63,6 +68,7 @@ export default defineConfig({
     exclude: [
       "@automerge/automerge-subduction",
       "@automerge/automerge-subduction/slim",
+      "@automerge/automerge-repo-keyhive",
     ],
   },
   build: {

--- a/sites/gaios/vite.config.ts
+++ b/sites/gaios/vite.config.ts
@@ -33,7 +33,10 @@ export default defineConfig({
           DEV: "data:text/javascript,export%20const%20DEV%20=%20true;",
         },
       },
-      extraBuiltins: ["@automerge/automerge-repo-keyhive"],
+      extraBuiltins: {
+        "@automerge/automerge-repo-keyhive":
+          "/packages/@automerge/automerge-repo-keyhive/index.js",
+      },
     }),
   ],
   worker: {

--- a/sites/tiny-patchwork/src/main.ts
+++ b/sites/tiny-patchwork/src/main.ts
@@ -1,7 +1,9 @@
 import "./global.css";
 
-import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
+declare const __KEYHIVE__: boolean;
+
 import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { bootPatchworkSite } from "@inkandswitch/patchwork-bootloader/site";
 
 // Published tools are registered in this module-settings doc via
 // `pnpm register` from each tool's own repo (see patchwork-tools and
@@ -14,4 +16,5 @@ await bootPatchworkSite({
   defaultModulesUrl: DEFAULT_MODULES_URL,
   accountStorageKey: "tinyPatchworkAccountUrl",
   titleSuffix: "patchwork",
+  keyhive: __KEYHIVE__,
 });

--- a/sites/tiny-patchwork/vite.config.ts
+++ b/sites/tiny-patchwork/vite.config.ts
@@ -20,6 +20,10 @@ const subductionDir = dirname(
 );
 
 export default defineConfig({
+  define: {
+    __SITE_NAME__: JSON.stringify("tiny-patchwork"),
+    __KEYHIVE__: JSON.stringify(process.env.KEYHIVE === "true"),
+  },
   plugins: [
     tailwindcss(),
     wasm(),
@@ -28,6 +32,10 @@ export default defineConfig({
         imports: {
           DEV: "data:text/javascript,export%20const%20DEV%20=%20true;",
         },
+      },
+      extraBuiltins: {
+        "@automerge/automerge-repo-keyhive":
+          "/packages/@automerge/automerge-repo-keyhive/index.js",
       },
     }),
   ],
@@ -63,6 +71,7 @@ export default defineConfig({
     exclude: [
       "@automerge/automerge-subduction",
       "@automerge/automerge-subduction/slim",
+      "@automerge/automerge-repo-keyhive",
     ],
   },
   build: {


### PR DESCRIPTION
Adds `keyhive` access control to tiny patchwork and gaios. 

I've included the ability to turn keyhive off.

* Both the service worker and the tab initialize their repos through the `automerge-repo-keyhive` API. The service worker uses a Rust variant (`initializeAutomergeRepoKeyhiveRust`) to talk to the keyhive sync server and the tab side uses the TS-based variant. Eventually these will be unified. 
* The tab-to-SW `MessageChannel` is wrapped in a keyhive network adapters. 
* The patchwork-view element gained access-level awareness. Before rendering a document, `patchwork-view`  checks for access and enters an "unable" state if there is none. It also listens for keyhive sync events and reactively re-evaluates access. If access is granted to a previously unavailable document, it re-initializes. If access is revoked on a displayed document, it tears down and re-inits into the unable state. 
* The Vite configs for both TPW and gaios define a `__SITE_NAME__` constant used to namespace keyhive's IndexedDB storage per site.

NOTE: This still has some local linking in it. I'm waiting for PRs against keyhive and subduction to land (and subsequent releases of those and then automerge-repo-keyhive) to update deps here. 
TODO once these land:
- [x] replace temporary local links with `catalog:`
- [x] replace `peerDependencies` "*" values in `core/bootloader/package.json` with `catalog:`
- [x] Update subduction endpoint from `localhost:3030` to keyhive sync server