### PR TITLE
Edge handles

### DIFF
--- a/packages/edge-handles/package.json
+++ b/packages/edge-handles/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@inkandswitch/edge-handles",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Doc-backed reactive cells with named upstream/downstream connections.",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc -w --preserveWatchOutput",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./dom": {
+      "import": "./dist/dom.js",
+      "types": "./dist/dom.d.ts"
+    }
+  },
+  "peerDependencies": {
+    "@automerge/automerge-repo": "*"
+  },
+  "devDependencies": {
+    "@automerge/automerge": "catalog:",
+    "@automerge/automerge-repo": "catalog:",
+    "@automerge/automerge-subduction": "catalog:",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/edge-handles/readme.md
+++ b/packages/edge-handles/readme.md
@@ -1,0 +1,176 @@
+# @inkandswitch/edge-handles
+
+A doc-backed reactive cell with named upstream and downstream connections —
+the minimum primitive you need to build dataflow systems where the wires
+themselves are first-class, sharable, persistent documents.
+
+EdgeHandles are deliberately **not** transformers. They are the shared
+primitive on which transformers, propagators, and other dataflow systems can
+be built. The package ships the primitive and a DOM↔handle bridge. Reference
+transforms (`identity`, `sum`, `template`, color, markdown, …) live in the
+[edge-handles examples tool](../../tools/edge-handles), kept out of the SDK
+so consumers ship only what they need.
+
+## Surface
+
+```ts
+// "@inkandswitch/edge-handles"
+
+/** Anything URL-addressable with a value-getter and a change subscription.
+ *  Both `Ref` and `EdgeHandle` implement it; edges chain into edges. */
+interface Handle<T = unknown> {
+  readonly url: HandleUrl;
+  value(): T;
+  onChange(cb: (v: T) => void): () => void;
+}
+
+class EdgeHandle<TValue = unknown> implements Handle<TValue | undefined> {
+  readonly url: AutomergeUrl;
+  readonly doc: DocHandle<EdgeHandleDoc>;
+
+  readonly source:       Record<string, Handle>;
+  readonly target:       Record<string, Handle>;
+  readonly sourceErrors: Record<string, Error>;
+  readonly targetErrors: Record<string, Error>;
+
+  value(): TValue | undefined;
+  change(fnOrValue: ChangeFn<TValue> | TValue): void;
+  onValueChange(cb: (v: TValue | undefined) => void): () => void;
+
+  onSourceChange(cb: (value: unknown, key: string) => void): () => void;
+  onMembersChange(cb: () => void): () => void;
+  onAnyChange(cb: (value: unknown, key: string | undefined) => void): () => void;
+
+  setSource(name: string, h: Handle | HandleUrl): void;
+  removeSource(name: string): void;
+  setTarget(name: string, h: Handle | HandleUrl): void;
+  removeTarget(name: string): void;
+
+  persisted(): boolean;
+  setPersisted(on: boolean): void;
+
+  destroy(): void;
+}
+
+createEdgeHandle<T>(repo, init?): Promise<EdgeHandle<T>>;
+findEdgeHandle<T>(repo, url):    Promise<EdgeHandle<T>>;
+```
+
+The value side mirrors `Ref`. The wire side is small and explicit: named
+maps, four mutators, three subscriptions.
+
+`onSourceChange` only fires on actual per-source value emissions, both args
+always defined. `onMembersChange` fires on the initial subscribe and on
+source/target membership changes. `onAnyChange` is sugar combining both:
+fires on subscribe and on any upstream change, with `(value, key)` set when
+a specific source emitted and both `undefined` otherwise.
+
+## Quick taste — three numbers feeding a sum
+
+```ts
+import { Repo } from "@automerge/automerge-repo";
+import { createEdgeHandle } from "@inkandswitch/edge-handles";
+
+const repo = new Repo();
+const a = repo.create({ value: 1 });
+const b = repo.create({ value: 2 });
+const c = repo.create({ value: 3 });
+const total = repo.create({ value: 0 });
+
+const edge = await createEdgeHandle<number>(repo, {
+  source: { a: a.ref("value"), b: b.ref("value"), c: c.ref("value") },
+  target: { total: total.ref("value") },
+});
+
+// Inline transform: re-sum on any upstream signal.
+edge.onAnyChange(() => {
+  let n = 0;
+  for (const src of Object.values(edge.source)) {
+    const v = src.value();
+    if (typeof v === "number" && Number.isFinite(v)) n += v;
+  }
+  edge.change(n);
+});                                // total.value is now 6
+a.change(d => { d.value = 10 });   // total.value becomes 15
+```
+
+## Handles
+
+Both `Ref` and `EdgeHandle` implement the `Handle` interface (`url`,
+`value()`, `onChange(cb)`). The URL form accepted by `setSource`/`setTarget`
+/`createEdgeHandle` is:
+
+- `automerge:abc123` — resolves to `handle.ref()`, the doc's root Ref.
+- `automerge:abc123/path...#heads?` — a `RefUrl`, resolves to a path-Ref.
+- `automerge:abc123` whose doc has `@patchwork.type === "edge-handle"` —
+  resolves to another `EdgeHandle`.
+
+Mutators validate URLs at edit time and throw on malformed input. Failures
+during resolution (e.g., a peer doc that hasn't synced yet) are captured in
+`edge.sourceErrors` / `edge.targetErrors` rather than silently dropped, and
+the next doc tick retries — so a slow-to-arrive peer eventually shows up
+without manual re-wiring.
+
+## Persistence
+
+By default an edge is in-memory only — `change()` doesn't touch the doc.
+Pass `persist: true` at create time (optionally with a `value`) to mirror
+every `change()` back to `doc.value`. Reopening the edge restores the
+cached value:
+
+```ts
+const edge = await createEdgeHandle<number>(repo, {
+  persist: true,
+  value: 0,
+});
+edge.change(42);                // doc.value is now 42
+edge.destroy();
+const reopened = await findEdgeHandle<number>(repo, edge.url);
+reopened.value();               // 42
+```
+
+`setPersisted(true | false)` flips the policy at runtime and updates
+`persisted()` synchronously.
+
+## Garbage collection
+
+The instance cache holds `WeakRef`s and a `FinalizationRegistry` tears down
+doc/endpoint listeners when the edge is collected. You don't need to call
+`destroy()` in normal flow — drop your reference and the runtime handles
+cleanup. `destroy()` exists for deterministic teardown (tests, hot reloads).
+
+## Subpaths
+
+- [`./dom`](./src/dom.ts) — small bridge helpers for reading handle URLs
+  off DOM nodes (`closestHandle`, `handleFromElement`).
+
+Reference transforms (the `identity`, `derive`, `sum`, `template`,
+`upper`/`lower`/`slugify`, `markdownToHtml`, `srgbToOklch`/`oklchToSrgb`,
+`accumulator`, `streamed` patterns) live in the
+[edge-handles examples tool](../../tools/edge-handles/src/patterns) — copy
+and adapt freely, but the SDK doesn't ship them.
+
+## Invariants
+
+1. **Handle addressability** — every handle URL resolves to a `Handle`, or
+   a typed `Error` lands in `sourceErrors` / `targetErrors`. Mutators reject
+   malformed URLs at edit time.
+2. **Resolution retries** — while any resolution errors are outstanding,
+   the next doc tick re-runs resolution (so still-loading peers eventually
+   succeed).
+3. **Referential equality (while live)** — `findEdgeHandle(repo, url)`
+   returns the same instance for the same `(repo, url)` pair as long as one
+   is still in memory. After GC, a fresh instance is constructed
+   transparently.
+4. **Member-change detection** — doc changes that don't touch `source`/
+   `target` (e.g. value-only mirrors) do not re-resolve handles or fire
+   `onMembersChange`. Value updates that are structurally equal to the
+   cached value don't re-fire `onValueChange` either.
+5. **Cycle safety at write time** — a re-entrancy guard inside `change()`
+   silently drops nested writes so cycles can't blow the stack. (No edit-
+   time cycle rejection; structurally cyclic graphs are allowed.)
+6. **Native change semantics** — writes delegate to each target's own
+   `change`; no bespoke merge logic. Fan-out is unconditional (including of
+   `undefined`) — higher-level semantics belong to consumers.
+7. **GC-safe** — unreferenced edges are collected; doc/endpoint listeners
+   tear themselves down via the FinalizationRegistry.

--- a/packages/edge-handles/src/dom.ts
+++ b/packages/edge-handles/src/dom.ts
@@ -1,0 +1,87 @@
+/**
+ * DOM <> handle bridge.
+ *
+ * Tools surface their automerge identity to the DOM via plain attributes so
+ * any other tool (or the platform itself) can ask "what does this DOM node
+ * represent in an automerge doc?" without coupling.
+ *
+ * We honour both the `<patchwork-view>` element's own `doc-url`/`tool-id`
+ * attributes and explicit `data-*` attributes on arbitrary elements:
+ *
+ * | Attribute       | Handle kind   |
+ * |-----------------|---------------|
+ * | `doc-url`       | DocHandle     |
+ * | `data-doc-url`  | DocHandle     |
+ * | `data-ref-url`  | Ref           |
+ * | `data-edge-url` | EdgeHandle    |
+ *
+ * Only the first matching attribute on a node is used. `closestHandle`
+ * walks ancestors so transforms can attach anywhere inside an embedded view.
+ *
+ * Note: the upstream `refFromObject(handle, value)` landing in
+ * `@automerge/automerge-repo` is a *different* primitive — it recovers a
+ * `Ref` from a sub-object you already have in hand. The two compose: walk
+ * the DOM here to get a URL, resolve it to a handle, then use
+ * `refFromObject` upstream to address sub-objects within that handle.
+ */
+
+import type { HandleUrl } from "./edge-handle.js";
+
+export interface HandleAttrs {
+  docUrlAttr: "doc-url";
+  dataDocUrlAttr: "data-doc-url";
+  dataRefUrlAttr: "data-ref-url";
+  dataEdgeUrlAttr: "data-edge-url";
+}
+
+export const HANDLE_ATTRS: HandleAttrs = {
+  docUrlAttr: "doc-url",
+  dataDocUrlAttr: "data-doc-url",
+  dataRefUrlAttr: "data-ref-url",
+  dataEdgeUrlAttr: "data-edge-url",
+};
+
+/** Read a handle URL directly off an element, without walking ancestors. */
+export function handleFromElement(el: Element): HandleUrl | undefined {
+  const direct =
+    el.getAttribute(HANDLE_ATTRS.dataRefUrlAttr) ??
+    el.getAttribute(HANDLE_ATTRS.dataEdgeUrlAttr) ??
+    el.getAttribute(HANDLE_ATTRS.dataDocUrlAttr) ??
+    el.getAttribute(HANDLE_ATTRS.docUrlAttr);
+  return direct ? (direct as HandleUrl) : undefined;
+}
+
+/**
+ * Walk up from `node` until we find an element carrying a handle URL.
+ * Returns `undefined` if there isn't one in the ancestor chain.
+ */
+export function closestHandle(node: Node | null): HandleUrl | undefined {
+  let el: Element | null =
+    node instanceof Element
+      ? node
+      : ((node && (node.parentElement as Element | null)) ?? null);
+  while (el) {
+    const found = handleFromElement(el);
+    if (found) return found;
+    el = el.parentElement;
+  }
+  return undefined;
+}
+
+/**
+ * Discover every handle-carrying element under `root`. Pass a custom
+ * `selector` to scope the search; the default finds all four supported
+ * attributes.
+ */
+export function querySelectorHandles(
+  root: ParentNode = document,
+  selector: string = `[${HANDLE_ATTRS.docUrlAttr}],[${HANDLE_ATTRS.dataDocUrlAttr}],[${HANDLE_ATTRS.dataRefUrlAttr}],[${HANDLE_ATTRS.dataEdgeUrlAttr}]`
+): { element: Element; url: HandleUrl }[] {
+  const out: { element: Element; url: HandleUrl }[] = [];
+  const elements = Array.from(root.querySelectorAll(selector));
+  for (const el of elements) {
+    const url = handleFromElement(el);
+    if (url) out.push({ element: el, url });
+  }
+  return out;
+}

--- a/packages/edge-handles/src/edge-handle.ts
+++ b/packages/edge-handles/src/edge-handle.ts
@@ -1,0 +1,851 @@
+/**
+ * EdgeHandle — a doc-backed reactive cell with named source and target
+ * connections to refs and other edges.
+ *
+ * The doc holds the persistent wiring (`source` and `target` maps, plus
+ * optional value persistence). The class is its live in-memory presence.
+ * EdgeHandles run no computation of their own; transforms are external
+ * code that subscribes to `onSourceChange` / `onMembersChange` (or the
+ * `onAnyChange` sugar) and writes back through `change`.
+ *
+ *     edge.value()                                  // current value
+ *     edge.change(fnOrValue)                        // Ref.change shape
+ *     edge.onValueChange(cb)                        // self value moved
+ *
+ *     edge.source / edge.target                     // resolved handles
+ *     edge.sourceErrors / edge.targetErrors         // per-name errors
+ *     edge.onSourceChange(cb)                       // (value, key): per-source
+ *                                                   //   emit, both args defined
+ *     edge.onMembersChange(cb)                      // (): membership changed
+ *                                                   //   (fires on subscribe)
+ *     edge.onAnyChange(cb)                          // sugar: either of the
+ *                                                   //   above, (value?, key?)
+ *
+ *     edge.setSource(name, handle) / removeSource(name)
+ *     edge.setTarget(name, handle) / removeTarget(name)
+ *
+ *     edge.persisted() / edge.setPersisted(on)      // doc-mirror policy
+ *
+ *     edge.destroy()                                // explicit teardown
+ *
+ * Live state is GC-able: unreferenced edges are collected, doc/endpoint
+ * listeners get torn down by a FinalizationRegistry, the cache holds only
+ * WeakRefs. You don't have to `destroy()` in normal flow.
+ */
+
+import {
+  findRef,
+  isValidAutomergeUrl,
+  parseAutomergeUrl,
+  type AutomergeUrl,
+  type ChangeFn,
+  type DocHandle,
+  type Ref,
+  type RefUrl,
+  type Repo,
+} from "@automerge/automerge-repo";
+
+// ─── subscriber set ────────────────────────────────────────────────────────
+
+class SubscriberSet<T = unknown> {
+  #subs = new Set<(value: T) => void>();
+  add(cb: (value: T) => void): () => void {
+    this.#subs.add(cb);
+    return () => {
+      this.#subs.delete(cb);
+    };
+  }
+  notify(value: T): void {
+    for (const cb of this.#subs) cb(value);
+  }
+}
+
+// ─── doc shape ─────────────────────────────────────────────────────────────
+
+/** `@patchwork.type` value used by EdgeHandle docs. */
+export const EDGE_HANDLE_DATATYPE = "edge-handle";
+
+/** Serialized URL of a `Handle` — `AutomergeUrl` for docs/edges, `RefUrl` for refs. */
+export type HandleUrl = AutomergeUrl | RefUrl;
+
+/**
+ * On-disk shape of an EdgeHandle doc.
+ *
+ * `persist` and `value` are independent optional fields:
+ *  - `persist: true` makes `change()` mirror its writes to `value`.
+ *  - `value` holds the last persisted value when `persist` is on.
+ */
+export interface EdgeHandleDoc {
+  "@patchwork": { type: typeof EDGE_HANDLE_DATATYPE; version: 1 };
+  /** Upstream handle URLs keyed by local name. */
+  source: { [name: string]: HandleUrl };
+  /** Downstream handle URLs keyed by local name. */
+  target: { [name: string]: HandleUrl };
+  /** When true, `change()` writes the value back to `value`. */
+  persist?: boolean;
+  /** Mirrored value when persistence is on. */
+  value?: unknown;
+}
+
+// ─── handle interface ──────────────────────────────────────────────────────
+
+/**
+ * What can sit at either end of an edge in memory: anything with a URL, a
+ * value getter, and a change subscription. `Ref` already implements this;
+ * `EdgeHandle` implements it too, so edges can chain into edges.
+ */
+export interface Handle<T = unknown> {
+  readonly url: HandleUrl;
+  value(): T;
+  onChange(cb: (value: T) => void): () => void;
+}
+
+function isEdgeHandle(h: Handle): h is EdgeHandle<any> {
+  return h instanceof EdgeHandle;
+}
+
+// ─── url validation ────────────────────────────────────────────────────────
+
+const URL_PREFIX = "automerge:";
+
+type HandleUrlKind = "doc-or-edge" | "ref" | "invalid";
+
+/** Cheap, IO-free classification of a handle URL. */
+function classifyHandleUrl(url: string): HandleUrlKind {
+  if (!url.startsWith(URL_PREFIX)) return "invalid";
+  const rest = url.slice(URL_PREFIX.length);
+  if (rest.length === 0) return "invalid";
+  const hashIx = rest.indexOf("#");
+  const beforeHash = hashIx === -1 ? rest : rest.slice(0, hashIx);
+  return beforeHash.includes("/") ? "ref" : "doc-or-edge";
+}
+
+/** Validate that a string is a syntactically well-formed handle URL. */
+function isValidHandleUrl(url: string): boolean {
+  const kind = classifyHandleUrl(url);
+  if (kind === "invalid") return false;
+  // Extract the documentId portion and validate it with the canonical check.
+  const rest = url.slice(URL_PREFIX.length);
+  const stops: number[] = [];
+  const slashIx = rest.indexOf("/");
+  const hashIx = rest.indexOf("#");
+  if (slashIx >= 0) stops.push(slashIx);
+  if (hashIx >= 0) stops.push(hashIx);
+  const endIx = stops.length === 0 ? rest.length : Math.min(...stops);
+  const docUrl = `${URL_PREFIX}${rest.slice(0, endIx)}`;
+  return isValidAutomergeUrl(docUrl);
+}
+
+function assertValidHandleUrl(url: string): asserts url is HandleUrl {
+  if (!isValidHandleUrl(url)) {
+    throw new Error(`[edge-handles] invalid handle URL: ${JSON.stringify(url)}`);
+  }
+}
+
+function toHandleUrl(h: Handle | HandleUrl): HandleUrl {
+  return typeof h === "string" ? h : (h.url as HandleUrl);
+}
+
+// ─── GC-safe teardown registry ─────────────────────────────────────────────
+
+interface TeardownBundle {
+  doc: DocHandle<EdgeHandleDoc>;
+  onDocChange: () => void;
+  sourceUnsubs: Map<string, () => void>;
+  repo: Repo;
+  url: AutomergeUrl;
+}
+
+const finalRegistry = new FinalizationRegistry<TeardownBundle>(
+  ({ doc, onDocChange, sourceUnsubs, repo, url }) => {
+    try {
+      doc.off("change", onDocChange);
+    } catch {
+      // doc may already be torn down — ignore
+    }
+    for (const u of sourceUnsubs.values()) {
+      try {
+        u();
+      } catch {
+        // best-effort
+      }
+    }
+    // The cache entry, if any, is a WeakRef pointing at the collected edge;
+    // remove the dead pointer so the next `find` doesn't bother dereffing.
+    const cache = resolvedByRepo.get(repo);
+    if (cache && cache.get(url)?.deref() === undefined) {
+      cache.delete(url);
+    }
+  }
+);
+
+// ─── EdgeHandle class ──────────────────────────────────────────────────────
+
+export class EdgeHandle<TValue = unknown>
+  implements Handle<TValue | undefined>
+{
+  readonly repo: Repo;
+  readonly doc: DocHandle<EdgeHandleDoc>;
+  readonly url: AutomergeUrl;
+
+  /** Live, resolved upstream handles keyed by local name. */
+  source: Record<string, Handle> = {};
+  /** Live, resolved downstream handles keyed by local name. */
+  target: Record<string, Handle> = {};
+  /** Resolution errors keyed by source name. Empty when everything resolved. */
+  sourceErrors: Record<string, Error> = {};
+  /**
+   * Errors keyed by target name. Resolution errors (URL didn't resolve to a
+   * live handle) and fan-out errors (write threw) share this map; both clear
+   * when their cause is resolved.
+   */
+  targetErrors: Record<string, Error> = {};
+
+  #value: TValue | undefined = undefined;
+  #persisted = false;
+  #valueSubscribers = new SubscriberSet<TValue | undefined>();
+  #sourceSubscribers = new SubscriberSet<{ value: unknown; key: string }>();
+  #membersSubscribers = new SubscriberSet<void>();
+  #sourceUnsubs = new Map<string, () => void>();
+  #docUnsub: (() => void) | null = null;
+  #destroyed = false;
+  #refreshGen = 0;
+  /** Re-entrancy guard so cycles can't blow the stack at write time. */
+  #writing = false;
+  #lastSourceJson = "";
+  #lastTargetJson = "";
+  #initVisited: Set<string>;
+  /** Used by listener closures so they don't pin `this` and block GC. */
+  #self: WeakRef<EdgeHandle<TValue>>;
+
+  /** @internal Use {@link createEdgeHandle} or {@link findEdgeHandle}. */
+  constructor(
+    repo: Repo,
+    doc: DocHandle<EdgeHandleDoc>,
+    options: { visited?: Set<string> } = {}
+  ) {
+    this.repo = repo;
+    this.doc = doc;
+    this.url = doc.url;
+    this.#initVisited = options.visited ?? new Set<string>();
+    this.#initVisited.add(doc.url);
+    this.#self = new WeakRef(this);
+  }
+
+  /** @internal Resolve handles and start watching the doc. */
+  async _init(): Promise<void> {
+    let initial: EdgeHandleDoc | undefined;
+    try {
+      initial = this.doc.doc();
+    } catch {
+      // unavailable / deleted — leave persisted=false, refresh will bail
+    }
+    if (initial?.persist === true) {
+      this.#persisted = true;
+      if ("value" in initial) this.#value = initial.value as TValue;
+    }
+
+    // Listener closure captures a WeakRef so it doesn't keep `this` alive.
+    // The DocHandle (long-lived via the Repo) would otherwise pin the edge.
+    const self = this.#self;
+    const onDocChange = () => {
+      const e = self.deref();
+      if (e) void e.#refreshEndpoints();
+    };
+    this.doc.on("change", onDocChange);
+    this.#docUnsub = () => this.doc.off("change", onDocChange);
+
+    finalRegistry.register(this, {
+      doc: this.doc,
+      onDocChange,
+      sourceUnsubs: this.#sourceUnsubs,
+      repo: this.repo,
+      url: this.url,
+    });
+
+    await this.#refreshEndpoints();
+  }
+
+  // ── value side ──────────────────────────────────────────────────────────
+
+  value(): TValue | undefined {
+    return this.#value;
+  }
+
+  /**
+   * Set or mutate the value. Same shape as `Ref.change`:
+   *  - direct value: replaces.
+   *  - callback `(prev) => next | void`: returning void leaves the value
+   *    unchanged; returning a value replaces.
+   *
+   * When persistence is on, writes the new value back to the doc. Fans out
+   * to every target (including writes of `undefined` — what targets do with
+   * a clear is their concern, not the cell's). Re-entrant calls during
+   * fan-out (cycles) are dropped.
+   */
+  change(fnOrValue: ChangeFn<TValue> | TValue): void {
+    if (this.#destroyed) return;
+    if (this.#writing) {
+      console.warn(
+        `[edge-handles] re-entrant change() on ${this.url} dropped (cycle)`
+      );
+      return;
+    }
+    this.#writing = true;
+    try {
+      let next: TValue | undefined;
+      if (typeof fnOrValue === "function") {
+        const cb = fnOrValue as (v: TValue | undefined) => TValue | void;
+        const result = cb(this.#value);
+        next = result === undefined ? this.#value : result;
+      } else {
+        next = fnOrValue;
+      }
+      this.#value = next;
+      if (this.#persisted) {
+        this.doc.change((d) => {
+          if (next === undefined) {
+            delete (d as { value?: unknown }).value;
+          } else {
+            (d as { value?: unknown }).value = next;
+          }
+        });
+      }
+      this.#fanOut(next);
+      this.#valueSubscribers.notify(next);
+    } finally {
+      this.#writing = false;
+    }
+  }
+
+  /** Subscribe to changes to this edge's value. Fires with the current
+   *  value on subscribe. */
+  onValueChange(cb: (value: TValue | undefined) => void): () => void {
+    const unsub = this.#valueSubscribers.add(cb);
+    cb(this.#value);
+    return unsub;
+  }
+
+  /** Handle conformance — alias for {@link onValueChange}. */
+  onChange(cb: (value: TValue | undefined) => void): () => void {
+    return this.onValueChange(cb);
+  }
+
+  // ── wire side ───────────────────────────────────────────────────────────
+
+  /**
+   * Fires when a specific source's value emits. Both `value` and `key` are
+   * always defined. Does NOT fire on initial subscribe and does NOT fire on
+   * membership changes — see {@link onMembersChange} for those.
+   */
+  onSourceChange(cb: (value: unknown, key: string) => void): () => void {
+    return this.#sourceSubscribers.add(({ value, key }) => cb(value, key));
+  }
+
+  /**
+   * Fires on initial subscribe and whenever source/target membership changes.
+   * The new wiring is on `edge.source` / `edge.target` by the time it fires.
+   *
+   * Most transforms want to recompute on any upstream change — they subscribe
+   * to both `onSourceChange` and `onMembersChange` with the same callback,
+   * or use the {@link onAnyChange} sugar.
+   */
+  onMembersChange(cb: () => void): () => void {
+    const unsub = this.#membersSubscribers.add(cb);
+    cb();
+    return unsub;
+  }
+
+  /**
+   * Sugar combining `onSourceChange` and `onMembersChange`. Fires on:
+   *  - initial subscribe — `cb(undefined, undefined)`
+   *  - membership changes — `cb(undefined, undefined)`
+   *  - per-source value emissions — `cb(value, key)`
+   *
+   * Use this when you just want "recompute on any upstream change" and
+   * don't care which kind. Use the precise pair when you do care.
+   */
+  onAnyChange(
+    cb: (value: unknown, key: string | undefined) => void
+  ): () => void {
+    const u1 = this.onSourceChange((value, key) => cb(value, key));
+    const u2 = this.onMembersChange(() => cb(undefined, undefined));
+    return () => {
+      u1();
+      u2();
+    };
+  }
+
+  /** Set or replace a source handle. Throws if the URL is malformed. */
+  setSource(name: string, handle: Handle | HandleUrl): void {
+    const url = toHandleUrl(handle);
+    assertValidHandleUrl(url);
+    this.doc.change((d) => {
+      d.source[name] = url;
+    });
+  }
+
+  /** Remove a source handle by name. */
+  removeSource(name: string): void {
+    this.doc.change((d) => {
+      delete d.source[name];
+    });
+  }
+
+  /** Set or replace a target handle. Throws if the URL is malformed. */
+  setTarget(name: string, handle: Handle | HandleUrl): void {
+    const url = toHandleUrl(handle);
+    assertValidHandleUrl(url);
+    this.doc.change((d) => {
+      d.target[name] = url;
+    });
+  }
+
+  /** Remove a target handle by name. */
+  removeTarget(name: string): void {
+    this.doc.change((d) => {
+      delete d.target[name];
+    });
+  }
+
+  // ── persistence ─────────────────────────────────────────────────────────
+
+  persisted(): boolean {
+    return this.#persisted;
+  }
+
+  /**
+   * Flip the persistence flag on the doc. Updates `persisted()` synchronously
+   * so the caller can rely on it immediately; the doc write happens in the
+   * same tick. Turning persistence on writes the current in-memory value to
+   * the doc; turning it off removes the cached value.
+   */
+  setPersisted(on: boolean): void {
+    if (this.#persisted === on) return;
+    this.#persisted = on;
+    const v = this.#value;
+    this.doc.change((d) => {
+      if (on) {
+        d.persist = true;
+        if (v !== undefined) (d as { value?: unknown }).value = v;
+      } else {
+        delete d.persist;
+        delete (d as { value?: unknown }).value;
+      }
+    });
+  }
+
+  // ── lifecycle ───────────────────────────────────────────────────────────
+
+  /**
+   * Explicit teardown. Idempotent. Use this when you want deterministic
+   * cleanup (tests, hot reloads); in production normal GC plus the
+   * FinalizationRegistry handle teardown without you doing anything.
+   */
+  destroy(): void {
+    if (this.#destroyed) return;
+    this.#destroyed = true;
+    for (const unsub of this.#sourceUnsubs.values()) unsub();
+    this.#sourceUnsubs.clear();
+    this.#docUnsub?.();
+    this.#docUnsub = null;
+    resolvedByRepo.get(this.repo)?.delete(this.url);
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  async #refreshEndpoints(): Promise<void> {
+    if (this.#destroyed) return;
+    const myGen = ++this.#refreshGen;
+
+    let next: EdgeHandleDoc | undefined;
+    try {
+      next = this.doc.doc();
+    } catch {
+      return;
+    }
+    if (!next) return;
+
+    // Sync persistence + value from the doc. Use structural equality so we
+    // don't notify on every refresh for object-valued edges (each automerge
+    // snapshot hands back a fresh view, reference-unequal to our cached one).
+    const docPersist = next.persist === true;
+    if (docPersist) {
+      this.#persisted = true;
+      const docValue = ("value" in next ? next.value : undefined) as
+        | TValue
+        | undefined;
+      if (!valuesEqual(docValue, this.#value)) {
+        this.#value = docValue;
+        this.#valueSubscribers.notify(this.#value);
+      }
+    } else if (this.#persisted) {
+      this.#persisted = false;
+    }
+
+    // Members: skip the rest if neither map changed AND we have no
+    // outstanding resolution errors (errors should be retried on the next
+    // doc tick — a peer that wasn't loaded before might be now).
+    const sourceUrls = next.source ?? {};
+    const targetUrls = next.target ?? {};
+    const sourceJson = JSON.stringify(sourceUrls);
+    const targetJson = JSON.stringify(targetUrls);
+    const hadErrors =
+      Object.keys(this.sourceErrors).length > 0 ||
+      Object.keys(this.targetErrors).length > 0;
+    if (
+      !hadErrors &&
+      sourceJson === this.#lastSourceJson &&
+      targetJson === this.#lastTargetJson
+    ) {
+      return;
+    }
+
+    const [sourceResolved, targetResolved] = await Promise.all([
+      resolveMap(this.repo, sourceUrls, this.#initVisited),
+      resolveMap(this.repo, targetUrls, this.#initVisited),
+    ]);
+    if (this.#destroyed || myGen !== this.#refreshGen) return;
+
+    const stillErrored =
+      Object.keys(sourceResolved.errors).length > 0 ||
+      Object.keys(targetResolved.errors).length > 0;
+
+    // Cache the snapshot only when resolution fully succeeded. Leaving the
+    // cache stale on errors means the next doc tick will retry.
+    if (stillErrored) {
+      this.#lastSourceJson = "";
+      this.#lastTargetJson = "";
+    } else {
+      this.#lastSourceJson = sourceJson;
+      this.#lastTargetJson = targetJson;
+    }
+
+    for (const unsub of this.#sourceUnsubs.values()) unsub();
+    this.#sourceUnsubs.clear();
+
+    this.source = sourceResolved.endpoints;
+    this.target = targetResolved.endpoints;
+    this.sourceErrors = sourceResolved.errors;
+    // Fan-out errors are reset on each refresh; subsequent writes will
+    // populate fresh ones if they fail.
+    this.targetErrors = targetResolved.errors;
+
+    // Per-source emission subscriptions. Listener closure captures a WeakRef
+    // to self so the subscription doesn't pin this edge.
+    const self = this.#self;
+    for (const [name, handle] of Object.entries(this.source)) {
+      const cb = (value: unknown) => {
+        const e = self.deref();
+        if (e) e.#sourceSubscribers.notify({ value, key: name });
+      };
+      const unsub = handle.onChange(cb);
+      this.#sourceUnsubs.set(name, unsub);
+    }
+
+    this.#membersSubscribers.notify();
+  }
+
+  #fanOut(value: TValue | undefined): void {
+    const writeErrors: Record<string, Error> = {};
+    for (const [name, handle] of Object.entries(this.target)) {
+      try {
+        if (isEdgeHandle(handle)) {
+          handle.change(value as never);
+        } else {
+          (handle as Ref<any>).change(value as never);
+        }
+      } catch (err) {
+        writeErrors[name] = err as Error;
+        console.error(
+          `[edge-handles] write to target.${name} (${handle.url}) failed`,
+          err
+        );
+      }
+    }
+    // Update targetErrors per-name: replace fan-out errors for the iterated
+    // names (success clears stale errors, failure sets fresh ones). Errors
+    // for names that aren't in `target` (i.e. resolution failures) are
+    // preserved.
+    if (Object.keys(this.target).length > 0) {
+      const next = { ...this.targetErrors };
+      for (const name of Object.keys(this.target)) {
+        if (writeErrors[name]) next[name] = writeErrors[name];
+        else delete next[name];
+      }
+      this.targetErrors = next;
+    }
+  }
+}
+
+// ─── value equality ────────────────────────────────────────────────────────
+
+/**
+ * Equality for cached values. Fast path for primitives via `Object.is`; for
+ * objects we fall back to JSON.stringify, which is good enough for the
+ * value shapes we expect (Automerge primitives + plain JSON-ish objects).
+ */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  if (a === null || b === null) return false;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+// ─── url resolution ────────────────────────────────────────────────────────
+
+/**
+ * Resolve a URL to a live `Handle`. Returns the handle on success or an
+ * `Error` describing the failure. The `visited` set breaks cycles in chains
+ * of edges.
+ */
+async function resolveHandleUrl(
+  repo: Repo,
+  url: HandleUrl,
+  visited: Set<string>
+): Promise<Handle | Error> {
+  const kind = classifyHandleUrl(url);
+  if (kind === "invalid") return new Error(`invalid handle URL: ${url}`);
+
+  if (kind === "ref") {
+    try {
+      return await findRef(repo, url as RefUrl);
+    } catch (err) {
+      return err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  let documentId;
+  try {
+    ({ documentId } = parseAutomergeUrl(url as AutomergeUrl));
+  } catch (err) {
+    return err instanceof Error
+      ? err
+      : new Error(`could not parse URL: ${url}`);
+  }
+
+  let handle: DocHandle<unknown>;
+  try {
+    handle = (await repo.find(documentId)) as DocHandle<unknown>;
+  } catch (err) {
+    return err instanceof Error
+      ? err
+      : new Error(`repo.find failed for ${url}`);
+  }
+
+  let doc: { "@patchwork"?: { type?: string } } | undefined;
+  try {
+    doc = handle.doc() as { "@patchwork"?: { type?: string } } | undefined;
+  } catch {
+    return new Error(`doc unavailable for ${url}`);
+  }
+
+  if (doc?.["@patchwork"]?.type === EDGE_HANDLE_DATATYPE) {
+    if (visited.has(handle.url)) {
+      return new Error(`cycle through edge ${handle.url}`);
+    }
+    const nextVisited = new Set(visited);
+    nextVisited.add(handle.url);
+    try {
+      return await openEdgeHandle(repo, handle.url, nextVisited);
+    } catch (err) {
+      return err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  try {
+    return handle.ref();
+  } catch (err) {
+    return err instanceof Error
+      ? err
+      : new Error(`handle.ref() failed for ${url}`);
+  }
+}
+
+interface ResolveMapResult {
+  endpoints: Record<string, Handle>;
+  errors: Record<string, Error>;
+}
+
+async function resolveMap(
+  repo: Repo,
+  urls: { [name: string]: HandleUrl },
+  initVisited: Set<string>
+): Promise<ResolveMapResult> {
+  const entries = Object.entries(urls);
+  if (entries.length === 0) return { endpoints: {}, errors: {} };
+  const resolved = await Promise.all(
+    entries.map(async ([name, url]) => {
+      const result = await resolveHandleUrl(repo, url, new Set(initVisited));
+      return { name, result };
+    })
+  );
+  const endpoints: Record<string, Handle> = {};
+  const errors: Record<string, Error> = {};
+  for (const { name, result } of resolved) {
+    if (result instanceof Error) errors[name] = result;
+    else endpoints[name] = result;
+  }
+  return { endpoints, errors };
+}
+
+// ─── factory + cache ───────────────────────────────────────────────────────
+
+/**
+ * In-flight cache: concurrent opens of the same `(repo, url)` share the
+ * same promise so referential equality holds across races.
+ */
+const pendingByRepo = new WeakMap<
+  Repo,
+  Map<string, Promise<EdgeHandle<any>>>
+>();
+
+/**
+ * Resolved cache: settled instances, held by `WeakRef` so we don't pin
+ * them when no caller holds a strong reference. Dead entries are pruned by
+ * the FinalizationRegistry on top of this file.
+ */
+const resolvedByRepo = new WeakMap<
+  Repo,
+  Map<string, WeakRef<EdgeHandle<any>>>
+>();
+
+function getPending(repo: Repo): Map<string, Promise<EdgeHandle<any>>> {
+  let m = pendingByRepo.get(repo);
+  if (!m) {
+    m = new Map();
+    pendingByRepo.set(repo, m);
+  }
+  return m;
+}
+
+function getResolved(repo: Repo): Map<string, WeakRef<EdgeHandle<any>>> {
+  let m = resolvedByRepo.get(repo);
+  if (!m) {
+    m = new Map();
+    resolvedByRepo.set(repo, m);
+  }
+  return m;
+}
+
+/** Initial values for a freshly created EdgeHandle doc. */
+export interface CreateEdgeHandleInit<TValue = unknown> {
+  source?: { [name: string]: Handle | HandleUrl };
+  target?: { [name: string]: Handle | HandleUrl };
+  /** Enable persisting the value to the doc (mirrors every `change()`). */
+  persist?: boolean;
+  /** Initial value; only written to the doc when `persist` is true. */
+  value?: TValue;
+}
+
+/** Create a fresh `EdgeHandleDoc` in the repo and return a live `EdgeHandle`. */
+export async function createEdgeHandle<T = unknown>(
+  repo: Repo,
+  init: CreateEdgeHandleInit<T> = {}
+): Promise<EdgeHandle<T>> {
+  const sourceUrls: Record<string, HandleUrl> = {};
+  for (const [name, h] of Object.entries(init.source ?? {})) {
+    const url = toHandleUrl(h);
+    assertValidHandleUrl(url);
+    sourceUrls[name] = url;
+  }
+  const targetUrls: Record<string, HandleUrl> = {};
+  for (const [name, h] of Object.entries(init.target ?? {})) {
+    const url = toHandleUrl(h);
+    assertValidHandleUrl(url);
+    targetUrls[name] = url;
+  }
+
+  const initial: EdgeHandleDoc = {
+    "@patchwork": { type: EDGE_HANDLE_DATATYPE, version: 1 },
+    source: sourceUrls,
+    target: targetUrls,
+  };
+  if (init.persist) {
+    initial.persist = true;
+    if (init.value !== undefined) initial.value = init.value;
+  }
+
+  const handle = repo.create<EdgeHandleDoc>(initial);
+  await handle.whenReady();
+  return openForDoc<T>(repo, handle, new Set());
+}
+
+/**
+ * Find an existing `EdgeHandle` by URL. Returns the cached instance for
+ * `(repo, url)` if one is still live; otherwise opens a fresh one. Throws
+ * if the URL does not point at an edge-handle doc.
+ *
+ * In-flight promises are deduplicated, so concurrent calls all await the
+ * same resolution.
+ */
+export async function findEdgeHandle<T = unknown>(
+  repo: Repo,
+  url: AutomergeUrl
+): Promise<EdgeHandle<T>> {
+  return openEdgeHandle<T>(repo, url, new Set());
+}
+
+/** Internal open used by both the public `findEdgeHandle` and chained-edge
+ *  resolution. The `visited` set propagates cycle detection. */
+async function openEdgeHandle<T = unknown>(
+  repo: Repo,
+  url: AutomergeUrl,
+  visited: Set<string>
+): Promise<EdgeHandle<T>> {
+  const pending = getPending(repo);
+  const existingPromise = pending.get(url);
+  if (existingPromise) return existingPromise as Promise<EdgeHandle<T>>;
+
+  const live = getResolved(repo).get(url)?.deref();
+  if (live) return live as EdgeHandle<T>;
+
+  const promise = (async () => {
+    const { documentId } = parseAutomergeUrl(url);
+    const handle = await repo.find<EdgeHandleDoc>(documentId);
+    await handle.whenReady();
+    let doc: { "@patchwork"?: { type?: string } } | undefined;
+    try {
+      doc = handle.doc();
+    } catch {
+      throw new Error(`findEdgeHandle: ${url} is unavailable`);
+    }
+    if (doc?.["@patchwork"]?.type !== EDGE_HANDLE_DATATYPE) {
+      throw new Error(
+        `findEdgeHandle: ${url} is not an edge-handle doc (type=${doc?.["@patchwork"]?.type})`
+      );
+    }
+    return openForDoc<T>(repo, handle, visited);
+  })();
+
+  pending.set(url, promise);
+  promise.then(
+    (edge) => {
+      pending.delete(url);
+      getResolved(repo).set(url, new WeakRef(edge));
+    },
+    () => {
+      pending.delete(url);
+    }
+  );
+  return promise;
+}
+
+async function openForDoc<T>(
+  repo: Repo,
+  handle: DocHandle<EdgeHandleDoc>,
+  visited: Set<string>
+): Promise<EdgeHandle<T>> {
+  const resolved = getResolved(repo);
+  const live = resolved.get(handle.url)?.deref();
+  if (live) return live as EdgeHandle<T>;
+
+  const edge = new EdgeHandle<T>(repo, handle, { visited });
+  resolved.set(handle.url, new WeakRef(edge));
+  await edge._init();
+  return edge;
+}

--- a/packages/edge-handles/src/index.ts
+++ b/packages/edge-handles/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  EDGE_HANDLE_DATATYPE,
+  type EdgeHandleDoc,
+  type HandleUrl,
+  type Handle,
+  EdgeHandle,
+  createEdgeHandle,
+  findEdgeHandle,
+  type CreateEdgeHandleInit,
+} from "./edge-handle.js";

--- a/packages/edge-handles/test/edge-handle.test.ts
+++ b/packages/edge-handles/test/edge-handle.test.ts
@@ -1,0 +1,686 @@
+import { type AutomergeUrl, Repo } from "@automerge/automerge-repo";
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+
+import {
+  createEdgeHandle,
+  EDGE_HANDLE_DATATYPE,
+  EdgeHandle,
+  findEdgeHandle,
+  type Handle,
+} from "../src/index.js";
+
+// Silence "unused EdgeHandle" import warning (used for types implicitly).
+void EdgeHandle;
+
+interface SrcDoc {
+  body: string;
+}
+interface NumDoc {
+  value: number;
+}
+interface SinkDoc {
+  html: string;
+}
+
+describe("EdgeHandle", () => {
+  let repo: Repo;
+  beforeEach(() => {
+    repo = new Repo();
+  });
+
+  // ─── doc shape ─────────────────────────────────────────────────────────
+
+  describe("doc shape", () => {
+    it("creates an edge-handle doc with empty source/target by default", async () => {
+      const edge = await createEdgeHandle(repo);
+      const doc = edge.doc.doc();
+      expect(doc["@patchwork"].type).toBe(EDGE_HANDLE_DATATYPE);
+      expect(doc["@patchwork"].version).toBe(1);
+      expect(doc.source).toEqual({});
+      expect(doc.target).toEqual({});
+      expect("persist" in doc).toBe(false);
+      expect("value" in doc).toBe(false);
+      expect(edge.source).toEqual({});
+      expect(edge.target).toEqual({});
+      expect(edge.sourceErrors).toEqual({});
+      expect(edge.targetErrors).toEqual({});
+    });
+
+    it("persists source/target as named maps of urls", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      const sink = repo.create<SinkDoc>({ html: "" });
+      await Promise.all([src.whenReady(), sink.whenReady()]);
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.ref("body") },
+        target: { t: sink.ref("html") },
+      });
+      expect(edge.doc.doc().source).toEqual({ s: src.ref("body").url });
+      expect(edge.doc.doc().target).toEqual({ t: sink.ref("html").url });
+      expect(Object.keys(edge.source)).toEqual(["s"]);
+      expect(Object.keys(edge.target)).toEqual(["t"]);
+    });
+
+    it("accepts urls or live handles in init", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { ref: src.ref("body"), url: src.ref("body").url },
+      });
+      expect(Object.keys(edge.source)).toEqual(["ref", "url"]);
+    });
+  });
+
+  // ─── value side ────────────────────────────────────────────────────────
+
+  describe("value side", () => {
+    it("starts undefined and fires onValueChange on initial subscribe", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      const seen: (number | undefined)[] = [];
+      edge.onValueChange((v) => seen.push(v));
+      expect(seen).toEqual([undefined]);
+    });
+
+    it("accepts the value form of change()", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      edge.change(42);
+      expect(edge.value()).toBe(42);
+    });
+
+    it("accepts the callback form of change()", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      edge.change(10);
+      edge.change((n) => (n ?? 0) + 5);
+      expect(edge.value()).toBe(15);
+    });
+
+    it("callback returning void leaves the value unchanged", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      edge.change(7);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      edge.change((_n) => undefined);
+      expect(edge.value()).toBe(7);
+    });
+
+    it("notifies onValueChange subscribers", async () => {
+      const edge = await createEdgeHandle<string>(repo);
+      const seen: (string | undefined)[] = [];
+      edge.onValueChange((v) => seen.push(v));
+      edge.change("a");
+      edge.change("b");
+      expect(seen).toEqual([undefined, "a", "b"]);
+    });
+
+    it("fans out value to target handles via their native change()", async () => {
+      const sink = repo.create<SinkDoc>({ html: "" });
+      await sink.whenReady();
+      const edge = await createEdgeHandle<string>(repo, {
+        target: { sink: sink.ref("html") },
+      });
+      edge.change("<h1>hi</h1>");
+      expect(sink.doc()?.html).toBe("<h1>hi</h1>");
+    });
+
+    it("change(undefined) still fans out to targets (no special semantics)", async () => {
+      const sink = repo.create<SinkDoc>({ html: "seed" });
+      await sink.whenReady();
+      const edge = await createEdgeHandle<string>(repo, {
+        target: { sink: sink.ref("html") },
+      });
+      // Ref.change(undefined) will write undefined into the doc; whether
+      // that's "useful" is a transform/datatype concern. The cell itself
+      // just hands the value to each target unconditionally.
+      const before = sink.doc()?.html;
+      edge.change(undefined as unknown as string);
+      // The Ref attempt may throw, in which case the error is recorded —
+      // either way, the cell isn't silently skipping the call.
+      const after = sink.doc()?.html;
+      const erroredAtSink = "sink" in edge.targetErrors;
+      expect(before === after || erroredAtSink || after === undefined).toBe(
+        true
+      );
+    });
+  });
+
+  // ─── persistence ───────────────────────────────────────────────────────
+
+  describe("persistence", () => {
+    it("does not persist by default (no persist flag or value in doc)", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      expect(edge.persisted()).toBe(false);
+      edge.change(42);
+      expect("value" in edge.doc.doc()).toBe(false);
+      expect("persist" in edge.doc.doc()).toBe(false);
+    });
+
+    it("persists value to the doc when init.persist is true", async () => {
+      const edge = await createEdgeHandle<number>(repo, {
+        persist: true,
+        value: 0,
+      });
+      expect(edge.persisted()).toBe(true);
+      expect(edge.doc.doc().persist).toBe(true);
+      expect(edge.doc.doc().value).toBe(0);
+      edge.change(42);
+      expect(edge.doc.doc().value).toBe(42);
+    });
+
+    it("persist:true without value still enables caching", async () => {
+      const edge = await createEdgeHandle<number>(repo, { persist: true });
+      expect(edge.persisted()).toBe(true);
+      expect("value" in edge.doc.doc()).toBe(false);
+      edge.change(7);
+      expect(edge.doc.doc().value).toBe(7);
+    });
+
+    it("restores a persisted value when re-opening the edge", async () => {
+      const edge = await createEdgeHandle<number>(repo, {
+        persist: true,
+        value: 0,
+      });
+      edge.change(123);
+      edge.destroy();
+      const reopened = await findEdgeHandle<number>(repo, edge.url);
+      expect(reopened.persisted()).toBe(true);
+      expect(reopened.value()).toBe(123);
+      reopened.change(456);
+      expect(reopened.doc.doc().value).toBe(456);
+    });
+
+    it("setPersisted(true) updates persisted() synchronously", async () => {
+      const edge = await createEdgeHandle<number>(repo);
+      edge.change(99);
+      expect(edge.persisted()).toBe(false);
+      edge.setPersisted(true);
+      // Reads synchronously:
+      expect(edge.persisted()).toBe(true);
+      // Doc write also lands synchronously since DocHandle.change is sync:
+      expect(edge.doc.doc().value).toBe(99);
+    });
+
+    it("setPersisted(false) clears persist and removes cached value", async () => {
+      const edge = await createEdgeHandle<number>(repo, {
+        persist: true,
+        value: 5,
+      });
+      edge.change(20);
+      edge.setPersisted(false);
+      expect(edge.persisted()).toBe(false);
+      expect("value" in edge.doc.doc()).toBe(false);
+      expect("persist" in edge.doc.doc()).toBe(false);
+      // In-memory value preserved:
+      expect(edge.value()).toBe(20);
+      // Subsequent writes don't persist:
+      edge.change(99);
+      expect("value" in edge.doc.doc()).toBe(false);
+    });
+
+    it("clears doc.value when change()d to undefined while persisting", async () => {
+      const edge = await createEdgeHandle<number>(repo, {
+        persist: true,
+        value: 10,
+      });
+      edge.change(undefined as unknown as number);
+      expect("value" in edge.doc.doc()).toBe(false);
+    });
+
+    it("does not spuriously re-notify on subsequent doc changes for object values", async () => {
+      const edge = await createEdgeHandle<{ n: number }>(repo, {
+        persist: true,
+        value: { n: 1 },
+      });
+      const seen: ({ n: number } | undefined)[] = [];
+      edge.onValueChange((v) => seen.push(v));
+      // Initial fire is one notification with the current value.
+      expect(seen.length).toBe(1);
+
+      // Trigger an unrelated doc mutation. The refresh re-reads doc.value
+      // (a new automerge view, reference-unequal) — but it's structurally
+      // equal, so we must NOT notify again.
+      edge.doc.change((d) => {
+        d.source["dummy"] = "automerge:dummy" as AutomergeUrl;
+      });
+      await wait(20);
+
+      // We expect at most one MORE notification (none, ideally). Most
+      // importantly, no notification storm.
+      expect(seen.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  // ─── wire side ─────────────────────────────────────────────────────────
+
+  describe("wire side", () => {
+    it("onSourceChange does NOT fire on subscribe", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.ref("body") },
+      });
+      const calls: [unknown, string][] = [];
+      edge.onSourceChange((value, key) => calls.push([value, key]));
+      expect(calls).toEqual([]);
+    });
+
+    it("onSourceChange fires (value, key) on per-source emissions", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.ref("body") },
+      });
+      const calls: [unknown, string][] = [];
+      edge.onSourceChange((value, key) => calls.push([value, key]));
+      src.change((d) => {
+        d.body = "world";
+      });
+      expect(calls).toEqual([["world", "s"]]);
+    });
+
+    it("onMembersChange fires on subscribe and on membership changes", async () => {
+      const src = repo.create<SrcDoc>({ body: "x" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo);
+      let fires = 0;
+      edge.onMembersChange(() => fires++);
+      expect(fires).toBe(1); // initial
+
+      edge.setSource("s", src.ref("body"));
+      await waitFor(() => fires >= 2);
+
+      edge.removeSource("s");
+      await waitFor(() => fires >= 3);
+    });
+
+    it("onAnyChange fires once on subscribe then on either kind of change", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo);
+      const calls: [unknown, string | undefined][] = [];
+      edge.onAnyChange((value, key) => calls.push([value, key]));
+      expect(calls).toEqual([[undefined, undefined]]);
+
+      edge.setSource("s", src.ref("body"));
+      await waitFor(() => calls.length >= 2);
+      // Membership change → (undefined, undefined)
+      expect(calls[calls.length - 1]).toEqual([undefined, undefined]);
+
+      src.change((d) => {
+        d.body = "world";
+      });
+      // Per-source emit → (value, key)
+      await waitFor(() => calls.length >= 3);
+      expect(calls[calls.length - 1]).toEqual(["world", "s"]);
+    });
+
+    it("re-resolves handles when source is mutated", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo);
+      expect(Object.keys(edge.source)).toEqual([]);
+      edge.setSource("s", src.ref("body"));
+      await waitFor(() => Object.keys(edge.source).length === 1);
+      expect(edge.source.s?.value()).toBe("hello");
+    });
+
+    it("removeSource deletes the binding", async () => {
+      const src = repo.create<SrcDoc>({ body: "hi" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.ref("body") },
+      });
+      edge.removeSource("s");
+      await waitFor(() => Object.keys(edge.source).length === 0);
+      expect(edge.doc.doc().source).toEqual({});
+    });
+
+    it("removeTarget deletes the binding", async () => {
+      const sink = repo.create<SinkDoc>({ html: "" });
+      await sink.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        target: { t: sink.ref("html") },
+      });
+      edge.removeTarget("t");
+      await waitFor(() => Object.keys(edge.target).length === 0);
+      expect(edge.doc.doc().target).toEqual({});
+    });
+
+    it("doc changes that only touch `value` don't re-fire members", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle<string>(repo, {
+        source: { s: src.ref("body") },
+        persist: true,
+        value: "",
+      });
+      let members = 0;
+      let sourceFires = 0;
+      edge.onMembersChange(() => members++);
+      edge.onSourceChange(() => sourceFires++);
+      const membersBefore = members;
+      const sourceBefore = sourceFires;
+
+      edge.change("a new value");
+      edge.change("another");
+      await wait(20);
+
+      expect(members).toBe(membersBefore);
+      expect(sourceFires).toBe(sourceBefore);
+    });
+  });
+
+  // ─── url validation ────────────────────────────────────────────────────
+
+  describe("url validation at edit time", () => {
+    it("setSource throws on a malformed URL", async () => {
+      const edge = await createEdgeHandle(repo);
+      expect(() => edge.setSource("bad", "not-a-url")).toThrow(/invalid/);
+      expect(() => edge.setSource("bad", "automerge:")).toThrow(/invalid/);
+      expect(() =>
+        edge.setSource("bad", "automerge:bad?" as AutomergeUrl)
+      ).toThrow(/invalid/);
+    });
+
+    it("setTarget throws on a malformed URL", async () => {
+      const edge = await createEdgeHandle(repo);
+      expect(() => edge.setTarget("bad", "garbage")).toThrow(/invalid/);
+    });
+
+    it("createEdgeHandle throws when init contains a malformed URL", async () => {
+      await expect(
+        createEdgeHandle(repo, { source: { bad: "automerge:" } })
+      ).rejects.toThrow(/invalid/);
+    });
+  });
+
+  // ─── error reporting ───────────────────────────────────────────────────
+
+  describe("endpoint resolution errors", () => {
+    it("captures an error for an unresolvable source URL written directly", async () => {
+      const edge = await createEdgeHandle(repo);
+      // Bypass `setSource`'s validation to simulate a stale URL that
+      // arrived via sync; the doc may still have a syntactically valid but
+      // unresolvable URL (e.g., for a doc that hasn't synced yet).
+      const ghost =
+        "automerge:3PMqSyMiYrNts9Ezy8T8WBQNpF2K" as AutomergeUrl;
+      edge.doc.change((d) => {
+        d.source["ghost"] = ghost;
+      });
+      await waitFor(
+        () => Object.keys(edge.sourceErrors).length > 0,
+        500
+      );
+      expect(edge.sourceErrors.ghost).toBeInstanceOf(Error);
+      expect(edge.source.ghost).toBeUndefined();
+    });
+
+    it("clears the error when the binding is removed", async () => {
+      const edge = await createEdgeHandle(repo);
+      const ghost =
+        "automerge:3PMqSyMiYrNts9Ezy8T8WBQNpF2K" as AutomergeUrl;
+      edge.doc.change((d) => {
+        d.source["ghost"] = ghost;
+      });
+      await waitFor(() => "ghost" in edge.sourceErrors);
+      edge.removeSource("ghost");
+      await waitFor(() => !("ghost" in edge.sourceErrors));
+      expect(edge.sourceErrors).toEqual({});
+    });
+
+    it("retries resolution on subsequent doc ticks while errors persist", async () => {
+      const edge = await createEdgeHandle(repo);
+      const ghost =
+        "automerge:3PMqSyMiYrNts9Ezy8T8WBQNpF2K" as AutomergeUrl;
+      edge.doc.change((d) => {
+        d.source["ghost"] = ghost;
+      });
+      await waitFor(() => "ghost" in edge.sourceErrors);
+
+      // Mutate an unrelated part of the doc; the refresh path should NOT
+      // skip resolution despite source-map being unchanged, because we have
+      // outstanding errors.
+      const before = edge.sourceErrors.ghost;
+      edge.doc.change((d) => {
+        d.target["t"] = "automerge:3PMqSyMiYrNts9Ezy8T8WBQNpF2L" as AutomergeUrl;
+      });
+      await wait(30);
+      // We can't easily prove "retry happened" without injecting a retryable
+      // failure source, but at least the error stays an Error and the
+      // sourceErrors entry persists (it doesn't disappear due to the cache
+      // skipping the refresh).
+      expect(edge.sourceErrors.ghost).toBeInstanceOf(Error);
+      // The error reference may or may not be the same — the point is the
+      // refresh runs.
+      void before;
+    });
+
+    it("fan-out errors clear on the next successful write", async () => {
+      // Use an EdgeHandle as the target so we can fail and recover it
+      // synchronously without mocking Refs.
+      const target = await createEdgeHandle<string>(repo);
+      const edge = await createEdgeHandle<string>(repo, {
+        target: { t: target },
+      });
+
+      // Sabotage `target.change` to throw on the next write, then succeed.
+      let shouldThrow = true;
+      const original = target.change.bind(target);
+      (target as { change: typeof target.change }).change = (v: unknown) => {
+        if (shouldThrow) {
+          shouldThrow = false;
+          throw new Error("sabotage");
+        }
+        return original(v as string);
+      };
+
+      edge.change("first");
+      expect(edge.targetErrors.t).toBeInstanceOf(Error);
+
+      edge.change("second");
+      expect("t" in edge.targetErrors).toBe(false);
+    });
+  });
+
+  // ─── plain doc urls ────────────────────────────────────────────────────
+
+  describe("plain doc urls resolve to root refs", () => {
+    it("resolves an automerge:docId url to handle.ref()", async () => {
+      const src = repo.create<SrcDoc>({ body: "hello" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.url },
+      });
+      const resolved = edge.source.s;
+      expect(resolved).toBeDefined();
+      expect((resolved as unknown as { path: unknown[] }).path).toEqual([]);
+      const v = resolved!.value() as SrcDoc;
+      expect(v.body).toBe("hello");
+    });
+  });
+
+  // ─── findEdgeHandle ────────────────────────────────────────────────────
+
+  describe("findEdgeHandle", () => {
+    it("returns the cached instance for the same url", async () => {
+      const edge = await createEdgeHandle(repo);
+      const reopened = await findEdgeHandle(repo, edge.url);
+      expect(reopened).toBe(edge);
+    });
+
+    it("dedupes concurrent calls to the same instance", async () => {
+      const edge = await createEdgeHandle(repo);
+      const [a, b, c] = await Promise.all([
+        findEdgeHandle(repo, edge.url),
+        findEdgeHandle(repo, edge.url),
+        findEdgeHandle(repo, edge.url),
+      ]);
+      expect(a).toBe(edge);
+      expect(b).toBe(edge);
+      expect(c).toBe(edge);
+    });
+
+    it("rejects when the url does not point at an edge-handle doc", async () => {
+      const other = repo.create<{ x: number }>({ x: 1 });
+      await other.whenReady();
+      await expect(findEdgeHandle(repo, other.url)).rejects.toThrow();
+    });
+  });
+
+  // ─── destroy ───────────────────────────────────────────────────────────
+
+  describe("destroy", () => {
+    it("destroy evicts the cache; reopen produces a fresh instance", async () => {
+      const edge = await createEdgeHandle(repo);
+      const url = edge.url;
+      edge.destroy();
+      const reopened = await findEdgeHandle(repo, url);
+      expect(reopened).not.toBe(edge);
+    });
+
+    it("destroy tears down source subscriptions (no further notifications)", async () => {
+      const src = repo.create<SrcDoc>({ body: "hi" });
+      await src.whenReady();
+      const edge = await createEdgeHandle(repo, {
+        source: { s: src.ref("body") },
+      });
+      const calls: [unknown, string][] = [];
+      edge.onSourceChange((value, key) => calls.push([value, key]));
+      const before = calls.length;
+      edge.destroy();
+      src.change((d) => {
+        d.body = "world";
+      });
+      await wait(10);
+      expect(calls.length).toBe(before);
+    });
+
+    it("destroy is idempotent", async () => {
+      const edge = await createEdgeHandle(repo);
+      edge.destroy();
+      expect(() => edge.destroy()).not.toThrow();
+    });
+  });
+
+  // ─── cycle safety ──────────────────────────────────────────────────────
+
+  describe("cycle safety", () => {
+    it("write re-entrancy guard tolerates cycles without blowing the stack", async () => {
+      const a = await createEdgeHandle<string>(repo);
+      const b = await createEdgeHandle<string>(repo, { target: { a } });
+      a.doc.change((d) => {
+        d.target.b = b.url;
+      });
+      await wait(30);
+      expect(() => a.change("ping")).not.toThrow();
+    });
+
+    it("allows setting source/target without an edit-time cycle check", async () => {
+      const a = await createEdgeHandle(repo);
+      const b = await createEdgeHandle(repo, { source: { a } });
+      expect(() => a.setSource("b", b)).not.toThrow();
+    });
+  });
+
+  // ─── end-to-end with an inline transform ───────────────────────────────
+
+  describe("end-to-end with an inline transform", () => {
+    it("multi-source sum routes through to a target on any input change", async () => {
+      const a = repo.create<NumDoc>({ value: 1 });
+      const b = repo.create<NumDoc>({ value: 2 });
+      const c = repo.create<NumDoc>({ value: 3 });
+      const total = repo.create<NumDoc>({ value: 0 });
+      await Promise.all([
+        a.whenReady(),
+        b.whenReady(),
+        c.whenReady(),
+        total.whenReady(),
+      ]);
+      const edge = await createEdgeHandle<number>(repo, {
+        source: {
+          a: a.ref("value"),
+          b: b.ref("value"),
+          c: c.ref("value"),
+        },
+        target: { total: total.ref("value") },
+      });
+      edge.onAnyChange(() => {
+        let n = 0;
+        for (const src of Object.values(edge.source)) {
+          const v = src.value();
+          if (typeof v === "number" && Number.isFinite(v)) n += v;
+        }
+        edge.change(n);
+      });
+
+      await waitFor(() => total.doc()?.value === 6);
+      a.change((d) => {
+        d.value = 10;
+      });
+      await waitFor(() => total.doc()?.value === 15);
+    });
+  });
+
+  // ─── edge → edge chaining ──────────────────────────────────────────────
+
+  describe("edge → edge chaining", () => {
+    it("an EdgeHandle in `target` relays writes through to its own targets", async () => {
+      const sink = repo.create<SinkDoc>({ html: "" });
+      await sink.whenReady();
+      const inner = await createEdgeHandle<string>(repo, {
+        target: { sink: sink.ref("html") },
+      });
+      const outer = await createEdgeHandle<string>(repo, {
+        target: { inner },
+      });
+      outer.change("relayed");
+      await waitFor(() => sink.doc()?.html === "relayed");
+    });
+
+    it("EdgeHandle implements the Handle interface", async () => {
+      const edge = await createEdgeHandle<string>(repo);
+      expect(typeof edge.url).toBe("string");
+      expect(typeof edge.value).toBe("function");
+      expect(typeof edge.onChange).toBe("function");
+
+      const seen: (string | undefined)[] = [];
+      const unsub = edge.onChange((v) => seen.push(v));
+      edge.change("hi");
+      expect(seen).toEqual([undefined, "hi"]);
+      unsub();
+    });
+
+    it("Ref implements the Handle interface", async () => {
+      const src = repo.create<SrcDoc>({ body: "hi" });
+      await src.whenReady();
+      const ref = src.ref("body");
+      // Compile-time conformance:
+      expectTypeOf(ref).toMatchTypeOf<Handle<unknown>>();
+      // Runtime shape:
+      expect(typeof ref.url).toBe("string");
+      expect(typeof ref.value).toBe("function");
+      expect(typeof ref.onChange).toBe("function");
+      // And subscribing works:
+      const seen: unknown[] = [];
+      const unsub = ref.onChange((v) => seen.push(v));
+      src.change((d) => {
+        d.body = "world";
+      });
+      await wait(10);
+      expect(seen).toContain("world");
+      unsub();
+    });
+  });
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+async function waitFor(predicate: () => boolean | undefined, timeoutMs = 500) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await wait(5);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for predicate`);
+}
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/edge-handles/test/setup.ts
+++ b/packages/edge-handles/test/setup.ts
@@ -1,0 +1,5 @@
+// Initialize the WASM modules that automerge-repo@subduction depends on
+// before any test runs. Importing the fat entry points auto-calls
+// initSync / UseApi().
+import "@automerge/automerge";
+import "@automerge/automerge-subduction";

--- a/packages/edge-handles/tsconfig.json
+++ b/packages/edge-handles/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/edge-handles/vitest.config.ts
+++ b/packages/edge-handles/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.{test,spec}.ts"],
+    setupFiles: ["./test/setup.ts"],
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,24 @@ importers:
         specifier: ^5.9.2
         version: 5.9.3
 
+  packages/edge-handles:
+    devDependencies:
+      '@automerge/automerge':
+        specifier: 3.3.0-fragments.1
+        version: 3.3.0-fragments.1
+      '@automerge/automerge-repo':
+        specifier: 2.6.0-subduction.23
+        version: 2.6.0-subduction.23
+      '@automerge/automerge-subduction':
+        specifier: 0.13.0
+        version: 0.13.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.9.1)(@vitest/ui@3.2.4)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.44.0)
+
   packages/providers/core:
     devDependencies:
       '@automerge/automerge-repo':

--- a/tools/edge-handles/.gitignore
+++ b/tools/edge-handles/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.pushwork/automerge
+.pushwork/snapshot.json

--- a/tools/edge-handles/package.json
+++ b/tools/edge-handles/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@inkandswitch/edge-handles-examples",
+  "version": "0.0.1",
+  "description": "Demo tools showcasing the edge-handles primitive. Ships edge-pair, wired-space, and friends.",
+  "type": "module",
+  "private": true,
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "push": "pnpm build && pushwork sync"
+  },
+  "dependencies": {
+    "@automerge/automerge-repo": "catalog:",
+    "@automerge/automerge-repo-solid-primitives": "catalog:",
+    "@inkandswitch/edge-handles": "workspace:*",
+    "solid-js": "^1.9.0"
+  },
+  "peerDependencies": {
+    "@inkandswitch/patchwork-elements": "*",
+    "@inkandswitch/patchwork-filesystem": "*",
+    "@inkandswitch/patchwork-plugins": "*"
+  },
+  "devDependencies": {
+    "@inkandswitch/patchwork-bootloader": "workspace:*",
+    "@inkandswitch/patchwork-elements": "workspace:*",
+    "@inkandswitch/patchwork-filesystem": "workspace:*",
+    "@inkandswitch/patchwork-plugins": "workspace:*",
+    "typescript": "~5.9.3",
+    "vite": "^7.0.0",
+    "vite-plugin-solid": "^2.11.0"
+  }
+}

--- a/tools/edge-handles/readme.md
+++ b/tools/edge-handles/readme.md
@@ -1,0 +1,71 @@
+# @inkandswitch/edge-handles-examples
+
+Demo tools and reference transforms built on top of
+[`@inkandswitch/edge-handles`](../../packages/edge-handles).
+
+This bundle ships two patchwork tools — `edge-pair` (a side-by-side preview
+wired by one edge) and `wired-space` (a spatial canvas where you draw
+arrows between docs) — plus a `patterns/` directory of small reference
+transforms (`identity`, `sum`, `template`, `markdownToHtml`,
+`srgbToOklch`/`oklchToSrgb`, etc.). The SDK itself contains only the
+primitive; everything else lives here.
+
+## Tools
+
+### edge-pair
+
+Renders the first two documents in a folder as side-by-side `<patchwork-view>`
+panes, then wires them together with an `EdgeHandle`. The attached transform
+is selectable from a toolbar.
+
+1. Create a folder.
+2. Drop two markdown (or text) docs into it.
+3. Open the folder with the **Edge Pair** tool.
+4. Type into the left pane. Watch the right pane update in real time.
+
+### wired-space
+
+A spatial canvas of cards (one per doc in the folder) and hyperedge nodes
+(one per `EdgeHandle`). Drag from a card's right port to another's left to
+wire them. Hover a wire endpoint to see its path; click to edit, alt+click
+to detach. Click an edge node to open the inspector and switch transforms.
+
+## Patterns
+
+`src/patterns/` is a library of reference transforms. Each is a small
+self-contained file showing the universal `onAnyChange → read sources →
+compute → change` loop. Copy and adapt freely.
+
+- `identity` — pass the first source through unchanged.
+- `derive` — run a pure projection over named sources.
+- `sum` — sum every numeric source.
+- `template` — render a template string over named sources.
+- `upper` / `lower` / `slugify` — single-source text transforms.
+- `markdownToHtml` — render markdown into HTML.
+- `srgbToOklch` / `oklchToSrgb` — colour space conversions.
+- `accumulator` — fold incoming changes into a running state.
+- `streamed` — async with abort-driven latest-wins scheduling.
+
+## Build & deploy
+
+```sh
+pnpm install
+pnpm push      # builds with vite and runs `pushwork sync`
+```
+
+## How it works
+
+```
+[ folder doc ]
+      │
+      ▼
+  edge-pair / wired-space tool
+   ├─ <patchwork-view> per child doc
+   └─ EdgeHandle (a real automerge doc of type "edge-handle")
+        source: { src: <ref-url> }
+        target: { sink: <ref-url> }
+        + a locally-attached transform from ./patterns
+```
+
+The `EdgeHandle` persists alongside the source and sink, so the wiring
+survives reloads as long as the underlying docs are reachable.

--- a/tools/edge-handles/src/edge-pair-tool.ts
+++ b/tools/edge-handles/src/edge-pair-tool.ts
@@ -1,0 +1,370 @@
+/**
+ * Folder tool: side-by-side two-pane preview wired by a single EdgeHandle.
+ *
+ * Demonstrates the simplest possible wired-system in this design:
+ * one source ref, one target ref, one transform attached locally. The
+ * persisted edge URL on the folder doc is the bridge across mounts.
+ */
+
+import type { AutomergeUrl, DocHandle, Repo } from "@automerge/automerge-repo";
+import type {
+  Plugin,
+  Tool,
+  ToolElement,
+} from "@inkandswitch/patchwork-plugins";
+import type {
+  FolderDoc,
+  DocLink,
+} from "@inkandswitch/patchwork-filesystem";
+import {
+  createEdgeHandle,
+  findEdgeHandle,
+  type EdgeHandle,
+} from "@inkandswitch/edge-handles";
+import * as patterns from "./patterns/index.js";
+
+interface EdgePairConfig {
+  edgeUrl?: AutomergeUrl;
+  transformId?: string;
+}
+type FolderDocWithEdgePair = FolderDoc & { edgePair?: EdgePairConfig };
+
+/**
+ * The local transform table. Each entry is a name -> attach function.
+ * This is intentionally tool-private — the package doesn't ship a registry,
+ * so consumers choose what their tool exposes.
+ */
+const TRANSFORMS: Record<string, (edge: EdgeHandle<any>) => () => void> = {
+  identity: patterns.identity,
+  "text/upper": patterns.upper,
+  "text/lower": patterns.lower,
+  "text/slugify": patterns.slugify,
+  "text/markdown-to-html": patterns.markdownToHtml,
+  "color/srgb-to-oklch": patterns.srgbToOklch,
+  "color/oklch-to-srgb": patterns.oklchToSrgb,
+  "text/template": patterns.template("${a} ${b}"),
+};
+
+interface PaneState {
+  link: DocLink | null;
+  field: string;
+  handle: DocHandle<any> | null;
+}
+
+function renderEdgePair(
+  handle: DocHandle<FolderDocWithEdgePair>,
+  element: ToolElement
+): () => void {
+  const repo: Repo = element.repo;
+
+  element.style.cssText = `
+    display: grid;
+    grid-template-rows: auto 1fr;
+    width: 100%;
+    height: 100%;
+    background: var(--color-base-100, #fafbfd);
+  `;
+
+  // ─ toolbar ────────────────────────────────────────────────────────────────
+  const toolbar = document.createElement("div");
+  toolbar.style.cssText = `
+    display:flex;flex-wrap:wrap;align-items:center;gap:6px;
+    padding:6px 10px;border-bottom:1px solid rgba(120,140,200,0.18);
+    font-size:12px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+  `;
+  element.appendChild(toolbar);
+
+  const heading = document.createElement("span");
+  heading.textContent = "edge-pair";
+  heading.style.cssText =
+    "font-weight:600;margin-right:8px;color:rgba(80,90,160,0.85);";
+  toolbar.appendChild(heading);
+
+  const sourceLabel = makeLabel("source");
+  toolbar.appendChild(sourceLabel);
+  const sourceField = makeFieldInput("content");
+  toolbar.appendChild(sourceField);
+
+  toolbar.appendChild(arrow());
+  const transformSelect = document.createElement("select");
+  transformSelect.style.cssText = selectStyle();
+  for (const id of Object.keys(TRANSFORMS).sort()) {
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = id;
+    transformSelect.appendChild(opt);
+  }
+  toolbar.appendChild(transformSelect);
+  toolbar.appendChild(arrow());
+
+  toolbar.appendChild(makeLabel("sink"));
+  const sinkField = makeFieldInput("content");
+  toolbar.appendChild(sinkField);
+
+  const swapBtn = makeButton("swap", () => swap());
+  toolbar.appendChild(swapBtn);
+
+  const status = document.createElement("span");
+  status.style.cssText = `
+    margin-left:auto;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    font-size:10px;opacity:0.55;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:50%;
+  `;
+  toolbar.appendChild(status);
+
+  // ─ panes ──────────────────────────────────────────────────────────────────
+  const split = document.createElement("div");
+  split.style.cssText = `
+    display:grid;grid-template-columns:1fr 1fr;gap:1px;min-height:0;
+    background:rgba(120,140,200,0.18);
+  `;
+  element.appendChild(split);
+
+  const sourcePane = makePane("Source");
+  const sinkPane = makePane("Sink");
+  split.appendChild(sourcePane.wrap);
+  split.appendChild(sinkPane.wrap);
+
+  // ─ state ──────────────────────────────────────────────────────────────────
+  const sourceState: PaneState = { link: null, handle: null, field: "content" };
+  const sinkState: PaneState = { link: null, handle: null, field: "content" };
+
+  let edge: EdgeHandle<unknown> | null = null;
+  let detach: (() => void) | null = null;
+  let transformId =
+    handle.doc()?.edgePair?.transformId ??
+    (Object.keys(TRANSFORMS).includes("identity") ? "identity" : Object.keys(TRANSFORMS)[0]);
+  transformSelect.value = transformId;
+
+  let cancelled = false;
+  let setupGen = 0;
+
+  // ─ wiring lifecycle ───────────────────────────────────────────────────────
+  const teardown = () => {
+    detach?.();
+    detach = null;
+    edge?.destroy();
+    edge = null;
+  };
+
+  const reconcile = async () => {
+    teardown();
+    const gen = ++setupGen;
+    if (!sourceState.handle || !sinkState.handle) {
+      status.textContent = "edge: pick a source + sink";
+      return;
+    }
+    const sourceRef = sourceState.handle.ref(sourceState.field);
+    const targetRef = sinkState.handle.ref(sinkState.field);
+    try {
+      const persistedUrl = handle.doc()?.edgePair?.edgeUrl;
+      let next: EdgeHandle<unknown>;
+      if (persistedUrl) {
+        try {
+          next = await findEdgeHandle(repo, persistedUrl);
+          next.setSource("src", sourceRef);
+          next.setTarget("sink", targetRef);
+        } catch {
+          // edge doc missing/invalid; fall through to create
+          next = await createEdgeHandle(repo, {
+            source: { src: sourceRef },
+            target: { sink: targetRef },
+          });
+          handle.change((d) => {
+            if (!d.edgePair) d.edgePair = {};
+            d.edgePair.edgeUrl = next.url;
+          });
+        }
+      } else {
+        next = await createEdgeHandle(repo, {
+          source: { src: sourceRef },
+          target: { sink: targetRef },
+        });
+        handle.change((d) => {
+          if (!d.edgePair) d.edgePair = {};
+          d.edgePair.edgeUrl = next.url;
+        });
+      }
+      if (cancelled || gen !== setupGen) {
+        next.destroy();
+        return;
+      }
+      edge = next;
+      const attach = TRANSFORMS[transformId];
+      detach = attach ? attach(edge) : null;
+      status.textContent = `edge: ${shortUrl(edge.url)} · transform: ${transformId}`;
+    } catch (err) {
+      status.textContent = `edge error: ${(err as Error).message}`;
+      console.error("[edge-pair] reconcile failed", err);
+    }
+  };
+
+  const ensureHandle = async (s: PaneState) => {
+    if (!s.link) {
+      s.handle = null;
+      return;
+    }
+    if (s.handle && s.handle.url === s.link.url) return;
+    s.handle = await repo.find(s.link.url);
+    await s.handle.whenReady();
+  };
+
+  const refreshAll = async () => {
+    await Promise.all([ensureHandle(sourceState), ensureHandle(sinkState)]);
+    await reconcile();
+  };
+
+  // ─ initial pick ───────────────────────────────────────────────────────────
+  const pickInitial = () => {
+    const links = handle.doc()?.docs ?? [];
+    const candidates = links.filter((l) => l.type !== "folder");
+    if (candidates[0]) {
+      sourceState.link = candidates[0];
+      sourcePane.setLink(candidates[0]);
+    }
+    if (candidates[1]) {
+      sinkState.link = candidates[1];
+      sinkPane.setLink(candidates[1]);
+    }
+  };
+  pickInitial();
+  void refreshAll();
+
+  const onFolderChange = () => {
+    if (!sourceState.link || !sinkState.link) {
+      pickInitial();
+      void refreshAll();
+    }
+  };
+  handle.on("change", onFolderChange);
+
+  // ─ user input ─────────────────────────────────────────────────────────────
+  sourceField.addEventListener("input", () => {
+    sourceState.field = sourceField.value || "content";
+    void reconcile();
+  });
+  sinkField.addEventListener("input", () => {
+    sinkState.field = sinkField.value || "content";
+    void reconcile();
+  });
+  transformSelect.addEventListener("change", () => {
+    transformId = transformSelect.value;
+    handle.change((d) => {
+      if (!d.edgePair) d.edgePair = {};
+      d.edgePair.transformId = transformId;
+    });
+    void reconcile();
+  });
+  function swap() {
+    const tmp = { ...sourceState };
+    Object.assign(sourceState, sinkState);
+    Object.assign(sinkState, tmp);
+    sourceField.value = sourceState.field;
+    sinkField.value = sinkState.field;
+    if (sourceState.link) sourcePane.setLink(sourceState.link);
+    if (sinkState.link) sinkPane.setLink(sinkState.link);
+    void reconcile();
+  }
+
+  // ─ cleanup ────────────────────────────────────────────────────────────────
+  return () => {
+    cancelled = true;
+    handle.off("change", onFolderChange);
+    teardown();
+    element.replaceChildren();
+    element.style.cssText = "";
+  };
+}
+
+// ─── DOM helpers ───────────────────────────────────────────────────────────
+
+function makePane(label: string) {
+  const wrap = document.createElement("div");
+  wrap.style.cssText = `
+    display:flex;flex-direction:column;min-width:0;min-height:0;
+    background:var(--color-base-100,#fff);
+  `;
+  const heading = document.createElement("div");
+  heading.style.cssText = `
+    padding:4px 10px;font-size:10px;text-transform:uppercase;letter-spacing:0.04em;
+    color:rgba(0,0,0,0.5);border-bottom:1px solid rgba(120,140,200,0.18);
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+  `;
+  heading.textContent = `${label} · (no doc)`;
+  wrap.appendChild(heading);
+  const view = document.createElement("patchwork-view");
+  (view as HTMLElement).style.cssText = "flex:1;min-height:0;min-width:0;display:flex;";
+  wrap.appendChild(view);
+  return {
+    wrap,
+    setLink(link: DocLink) {
+      heading.textContent = `${label} · ${link.name} (${link.type})`;
+      view.setAttribute("doc-url", link.url);
+    },
+  };
+}
+
+function makeFieldInput(initial: string) {
+  const input = document.createElement("input");
+  input.value = initial;
+  input.size = 8;
+  input.style.cssText = `
+    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;
+    padding:2px 6px;border:1px solid rgba(120,140,200,0.4);border-radius:4px;
+    background:transparent;color:inherit;width:9ch;
+  `;
+  return input;
+}
+
+function makeLabel(text: string) {
+  const s = document.createElement("span");
+  s.textContent = text;
+  s.style.opacity = "0.6";
+  return s;
+}
+
+function makeButton(text: string, onClick: () => void) {
+  const b = document.createElement("button");
+  b.textContent = text;
+  b.style.cssText = `
+    font-size:11px;padding:2px 8px;border-radius:4px;
+    border:1px solid rgba(120,140,200,0.4);background:transparent;color:inherit;
+    cursor:pointer;margin-left:4px;
+  `;
+  b.addEventListener("click", onClick);
+  return b;
+}
+
+function selectStyle() {
+  return `
+    font-size:11px;padding:2px 4px;border-radius:4px;
+    border:1px solid rgba(120,140,255,0.4);background:transparent;color:inherit;
+  `;
+}
+
+function arrow() {
+  const a = document.createElement("span");
+  a.textContent = "→";
+  a.style.cssText = "opacity:0.45;padding:0 2px;";
+  return a;
+}
+
+function shortUrl(url: string) {
+  if (url.length <= 20) return url;
+  return `${url.slice(0, 12)}…${url.slice(-6)}`;
+}
+
+// ─── Plugin registration ───────────────────────────────────────────────────
+
+export const edgePairPlugins: Plugin<any>[] = [
+  {
+    type: "patchwork:tool",
+    id: "edge-pair",
+    name: "Edge Pair",
+    icon: "Cable",
+    supportedDatatypes: ["folder"],
+    async load() {
+      return renderEdgePair;
+    },
+  } satisfies Tool<FolderDocWithEdgePair>,
+];

--- a/tools/edge-handles/src/index.ts
+++ b/tools/edge-handles/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Aggregate entry for the edge-handles demo bundle.
+ *
+ * Ships:
+ *
+ * - `patchwork:tool` `edge-pair`     — two-pane preview wired by an EdgeHandle.
+ * - `patchwork:tool` `wired-space`   — spatial canvas where you draw arrows
+ *                                     between docs to wire them.
+ *
+ * Transforms aren't registered as plugins — they live as small attach
+ * functions in `./patterns/` and are pulled in by each tool. Cross-tool
+ * transform sharing is a job for the future workflow layer.
+ */
+
+import type { Plugin } from "@inkandswitch/patchwork-plugins";
+
+import { edgePairPlugins } from "./edge-pair-tool.js";
+import { wiredSpacePlugins } from "./wired-space-tool.js";
+
+export const plugins: Plugin<any>[] = [
+  ...edgePairPlugins,
+  ...wiredSpacePlugins,
+];

--- a/tools/edge-handles/src/patterns/accumulator.ts
+++ b/tools/edge-handles/src/patterns/accumulator.ts
@@ -1,0 +1,28 @@
+/**
+ * Stateful accumulator — fold incoming source changes into a running value.
+ *
+ * Transforms can hold their own state across invocations. The state is
+ * local to the attach (the closure), not on the edge — the edge stays a
+ * pure cell.
+ *
+ *     const counts = accumulator(0, (n) => n + 1);
+ *     const detach = counts(edge);   // increments each time any source changes
+ */
+import type { EdgeHandle, Handle } from "@inkandswitch/edge-handles";
+
+export function accumulator<T>(
+  initial: T,
+  step: (prev: T, source: Record<string, Handle>) => T
+): (edge: EdgeHandle<T>) => () => void {
+  return (edge) => {
+    let state = initial;
+    edge.change(state);
+    // onAnyChange auto-fires on subscribe (via onMembersChange), running
+    // `tick` once to produce the first stepped state. Subsequent upstream
+    // changes step again.
+    return edge.onAnyChange(() => {
+      state = step(state, edge.source);
+      edge.change(state);
+    });
+  };
+}

--- a/tools/edge-handles/src/patterns/color.ts
+++ b/tools/edge-handles/src/patterns/color.ts
@@ -1,0 +1,163 @@
+/**
+ * Color conversions sRGB ↔ OKLch.
+ *
+ * Two patterns sharing one math kernel. Inputs and outputs are CSS strings.
+ * Math is the standard sRGB → linear sRGB → OKLab → OKLch pipeline
+ * (Björn Ottosson). Use a real CSS Color Module 4 library in production;
+ * this exists for live-demo legibility.
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+interface Oklch {
+  l: number;
+  c: number;
+  h: number;
+}
+
+const HEX3 = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
+const HEX6 = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+const RGB_FN = /^rgba?\(\s*([0-9.]+)\s*,\s*([0-9.]+)\s*,\s*([0-9.]+)/i;
+const OKLCH_FN = /^oklch\(\s*([0-9.]+%?)\s+([0-9.]+)\s+([0-9.]+)/i;
+
+function parseRgb(s: string): Rgb | undefined {
+  const t = s.trim();
+  const m6 = HEX6.exec(t);
+  if (m6) {
+    return {
+      r: parseInt(m6[1], 16) / 255,
+      g: parseInt(m6[2], 16) / 255,
+      b: parseInt(m6[3], 16) / 255,
+    };
+  }
+  const m3 = HEX3.exec(t);
+  if (m3) {
+    return {
+      r: parseInt(m3[1] + m3[1], 16) / 255,
+      g: parseInt(m3[2] + m3[2], 16) / 255,
+      b: parseInt(m3[3] + m3[3], 16) / 255,
+    };
+  }
+  const mr = RGB_FN.exec(t);
+  if (mr) {
+    return {
+      r: parseFloat(mr[1]) / 255,
+      g: parseFloat(mr[2]) / 255,
+      b: parseFloat(mr[3]) / 255,
+    };
+  }
+  return undefined;
+}
+
+function parseOklch(s: string): Oklch | undefined {
+  const m = OKLCH_FN.exec(s.trim());
+  if (!m) return undefined;
+  const lRaw = m[1];
+  const l = lRaw.endsWith("%") ? parseFloat(lRaw) / 100 : parseFloat(lRaw);
+  return { l, c: parseFloat(m[2]), h: parseFloat(m[3]) };
+}
+
+function clamp01(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x;
+}
+function gammaToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+function linearToGamma(c: number): number {
+  return c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+}
+
+function linearRgbToOklab({ r, g, b }: Rgb): {
+  L: number;
+  a: number;
+  b: number;
+} {
+  const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+  const m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+  const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+  const l_ = Math.cbrt(l),
+    m_ = Math.cbrt(m),
+    s_ = Math.cbrt(s);
+  return {
+    L: 0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_,
+    a: 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_,
+    b: 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_,
+  };
+}
+function oklabToLinearRgb(lab: { L: number; a: number; b: number }): Rgb {
+  const l_ = lab.L + 0.3963377774 * lab.a + 0.2158037573 * lab.b;
+  const m_ = lab.L - 0.1055613458 * lab.a - 0.0638541728 * lab.b;
+  const s_ = lab.L - 0.0894841775 * lab.a - 1.291485548 * lab.b;
+  const l = l_ ** 3,
+    m = m_ ** 3,
+    s = s_ ** 3;
+  return {
+    r: 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    g: -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    b: -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  };
+}
+
+function srgbToOklchObj(rgb: Rgb): Oklch {
+  const linear: Rgb = {
+    r: gammaToLinear(clamp01(rgb.r)),
+    g: gammaToLinear(clamp01(rgb.g)),
+    b: gammaToLinear(clamp01(rgb.b)),
+  };
+  const { L, a, b } = linearRgbToOklab(linear);
+  const c = Math.sqrt(a * a + b * b);
+  let h = (Math.atan2(b, a) * 180) / Math.PI;
+  if (h < 0) h += 360;
+  return { l: L, c, h };
+}
+function oklchToSrgbObj(o: Oklch): Rgb {
+  const a = o.c * Math.cos((o.h * Math.PI) / 180);
+  const b = o.c * Math.sin((o.h * Math.PI) / 180);
+  const lin = oklabToLinearRgb({ L: o.l, a, b });
+  return {
+    r: clamp01(linearToGamma(lin.r)),
+    g: clamp01(linearToGamma(lin.g)),
+    b: clamp01(linearToGamma(lin.b)),
+  };
+}
+function rgbToHex({ r, g, b }: Rgb): string {
+  const to2 = (c: number) =>
+    Math.round(clamp01(c) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${to2(r)}${to2(g)}${to2(b)}`;
+}
+function fmtOklch(o: Oklch): string {
+  return `oklch(${(o.l * 100).toFixed(1)}% ${o.c.toFixed(3)} ${o.h.toFixed(1)})`;
+}
+
+function firstStringSource(edge: EdgeHandle<string>): string {
+  const first = Object.values(edge.source)[0];
+  const v = first?.value();
+  return typeof v === "string" ? v.trim() : "";
+}
+
+export function srgbToOklch(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() => {
+    const src = firstStringSource(edge);
+    if (!src) return edge.change("");
+    if (src.toLowerCase().startsWith("oklch(")) return edge.change(src);
+    const rgb = parseRgb(src);
+    edge.change(rgb ? fmtOklch(srgbToOklchObj(rgb)) : src);
+  });
+}
+
+export function oklchToSrgb(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() => {
+    const src = firstStringSource(edge);
+    if (!src) return edge.change("");
+    if (src.startsWith("#") || src.toLowerCase().startsWith("rgb"))
+      return edge.change(src);
+    const o = parseOklch(src);
+    edge.change(o ? rgbToHex(oklchToSrgbObj(o)) : src);
+  });
+}

--- a/tools/edge-handles/src/patterns/derive.ts
+++ b/tools/edge-handles/src/patterns/derive.ts
@@ -1,0 +1,22 @@
+/**
+ * Run a pure projection over an edge's named sources.
+ *
+ * Configured by passing the projection function. Returns an
+ * `(edge) => detach` so it composes with whatever wiring code holds the edge.
+ *
+ * ```ts
+ * const detach = derive((source) => source.a.value() + source.b.value())(edge);
+ * ```
+ */
+import type { EdgeHandle, Handle } from "@inkandswitch/edge-handles";
+
+export function derive<T = unknown>(
+  fn: (source: Record<string, Handle>) => T | undefined
+): (edge: EdgeHandle<T>) => () => void {
+  return (edge) =>
+    edge.onAnyChange(() => {
+      const result = fn(edge.source);
+      if (result === undefined) return;
+      edge.change(result);
+    });
+}

--- a/tools/edge-handles/src/patterns/identity.ts
+++ b/tools/edge-handles/src/patterns/identity.ts
@@ -1,0 +1,15 @@
+/**
+ * Pass the first source's value straight through.
+ *
+ * The minimal transform — useful for routing where you want one source's
+ * value available at a different identity (the edge's own URL).
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+export function identity<T = unknown>(edge: EdgeHandle<T>): () => void {
+  return edge.onAnyChange(() => {
+    const first = Object.values(edge.source)[0];
+    if (!first) return;
+    edge.change(first.value() as T);
+  });
+}

--- a/tools/edge-handles/src/patterns/index.ts
+++ b/tools/edge-handles/src/patterns/index.ts
@@ -1,0 +1,21 @@
+/**
+ * A small library of reference transforms.
+ *
+ * Each pattern is self-contained — one file, one shape, no shared helpers —
+ * so reading a few patterns reveals the universal `subscribe → read sources →
+ * compute → change` loop. Copy and adapt freely; these are demo code and
+ * documentation, not a framework.
+ *
+ * Patterns aren't a registry either: there's no `attach()` here, no
+ * scheduler, no plugin glue. If you want those things, build them on top.
+ */
+
+export { identity } from "./identity.js";
+export { derive } from "./derive.js";
+export { sum } from "./sum.js";
+export { template } from "./template.js";
+export { upper, lower, slugify } from "./text.js";
+export { markdownToHtml } from "./markdown.js";
+export { srgbToOklch, oklchToSrgb } from "./color.js";
+export { streamed } from "./streamed.js";
+export { accumulator } from "./accumulator.js";

--- a/tools/edge-handles/src/patterns/markdown.ts
+++ b/tools/edge-handles/src/patterns/markdown.ts
@@ -1,0 +1,85 @@
+/**
+ * Markdown → HTML.
+ *
+ * A baby converter: no native deps, no worker, runs anywhere. Supports ATX
+ * headings, bullets, inline code/bold/italic, paragraphs. For richer output,
+ * write your own pattern around a real markdown library — the shape is the
+ * same: `onAnyChange → read first source → compute → change`.
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+export function markdownToHtml(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() => {
+    const first = Object.values(edge.source)[0];
+    const src = first?.value();
+    edge.change(convert(typeof src === "string" ? src : ""));
+  });
+}
+
+function convert(src: string): string {
+  const lines = src.replace(/\r\n/g, "\n").split("\n");
+  const out: string[] = [];
+  let listOpen = false;
+  let paraBuf: string[] = [];
+
+  const flushPara = () => {
+    if (paraBuf.length === 0) return;
+    out.push(`<p>${inline(paraBuf.join(" "))}</p>`);
+    paraBuf = [];
+  };
+  const closeList = () => {
+    if (listOpen) {
+      out.push("</ul>");
+      listOpen = false;
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (line.trim() === "") {
+      flushPara();
+      closeList();
+      continue;
+    }
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      flushPara();
+      closeList();
+      out.push(
+        `<h${heading[1].length}>${inline(heading[2])}</h${heading[1].length}>`
+      );
+      continue;
+    }
+    const bullet = /^\s*[-*]\s+(.*)$/.exec(line);
+    if (bullet) {
+      flushPara();
+      if (!listOpen) {
+        out.push("<ul>");
+        listOpen = true;
+      }
+      out.push(`<li>${inline(bullet[1])}</li>`);
+      continue;
+    }
+    paraBuf.push(line);
+  }
+  flushPara();
+  closeList();
+  return out.join("\n");
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function inline(s: string): string {
+  const codeSpans: string[] = [];
+  let out = escapeHtml(s).replace(/`([^`]+)`/g, (_m, code) => {
+    const ix = codeSpans.push(`<code>${code}</code>`) - 1;
+    return `\u0000CODE${ix}\u0000`;
+  });
+  out = out
+    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*([^*]+)\*/g, "<em>$1</em>");
+  out = out.replace(/\u0000CODE(\d+)\u0000/g, (_m, ix) => codeSpans[+ix]);
+  return out;
+}

--- a/tools/edge-handles/src/patterns/streamed.ts
+++ b/tools/edge-handles/src/patterns/streamed.ts
@@ -1,0 +1,59 @@
+/**
+ * Async transform with cancellation, expressed as an async iterable.
+ *
+ * Each input change starts a new run; previous in-flight runs are aborted
+ * via an `AbortSignal` so user code can cooperate. The canonical
+ * "latest-wins" scheduling shape, demonstrated with no hidden helper —
+ * cancellation plumbing is on screen.
+ *
+ *     const transform = streamed(async function* (source, signal) {
+ *       const src = source.src?.value();
+ *       if (typeof src !== "string") return;
+ *       for (const chunk of await renderChunked(src, signal)) {
+ *         if (signal.aborted) return;
+ *         yield chunk;
+ *       }
+ *     });
+ *     const detach = transform(edge);
+ */
+import type { EdgeHandle, Handle } from "@inkandswitch/edge-handles";
+
+export function streamed<T>(
+  fn: (
+    source: Record<string, Handle>,
+    signal: AbortSignal
+  ) => AsyncIterable<T> | Promise<T> | T
+): (edge: EdgeHandle<T>) => () => void {
+  return (edge) => {
+    let ctrl = new AbortController();
+    const run = async () => {
+      ctrl.abort();
+      ctrl = new AbortController();
+      const signal = ctrl.signal;
+      try {
+        const out = fn(edge.source, signal);
+        const result = await out;
+        if (
+          result &&
+          typeof (result as any)[Symbol.asyncIterator] === "function"
+        ) {
+          for await (const v of result as AsyncIterable<T>) {
+            if (signal.aborted) return;
+            edge.change(v);
+          }
+        } else if (result !== undefined) {
+          if (!signal.aborted) edge.change(result as T);
+        }
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
+          console.error("[edge-handles] streamed transform threw", err);
+        }
+      }
+    };
+    const unsub = edge.onAnyChange(() => void run());
+    return () => {
+      ctrl.abort();
+      unsub();
+    };
+  };
+}

--- a/tools/edge-handles/src/patterns/sum.ts
+++ b/tools/edge-handles/src/patterns/sum.ts
@@ -1,0 +1,18 @@
+/**
+ * Sum every numeric source. The canonical multi-input transform.
+ *
+ * Non-numeric or non-finite sources are filtered. Shows the basic
+ * "iterate named sources, project, emit" shape end-to-end.
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+export function sum(edge: EdgeHandle<number>): () => void {
+  return edge.onAnyChange(() => {
+    let total = 0;
+    for (const src of Object.values(edge.source)) {
+      const v = src.value();
+      if (typeof v === "number" && Number.isFinite(v)) total += v;
+    }
+    edge.change(total);
+  });
+}

--- a/tools/edge-handles/src/patterns/template.ts
+++ b/tools/edge-handles/src/patterns/template.ts
@@ -1,0 +1,26 @@
+/**
+ * Render a template string over named sources.
+ *
+ *     const t = template("Hello ${name}, you are ${age} years old");
+ *     const detach = t(edge);   // edge.source.name, edge.source.age supply values
+ *
+ * Placeholders are `${name}` and match keys on `edge.source`. Missing or
+ * non-stringable values render as the empty string. The "named sources buy
+ * you readability" demonstration.
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+const PLACEHOLDER = /\$\{(\w+)\}/g;
+
+export function template(
+  tpl: string
+): (edge: EdgeHandle<string>) => () => void {
+  return (edge) =>
+    edge.onAnyChange(() => {
+      const rendered = tpl.replace(PLACEHOLDER, (_, name) => {
+        const v = edge.source[name]?.value();
+        return v == null ? "" : String(v);
+      });
+      edge.change(rendered);
+    });
+}

--- a/tools/edge-handles/src/patterns/text.ts
+++ b/tools/edge-handles/src/patterns/text.ts
@@ -1,0 +1,36 @@
+/**
+ * Tiny text transforms over a single source. The "lift a unary function"
+ * shape, written out three times so the structure is plainly visible.
+ */
+import type { EdgeHandle } from "@inkandswitch/edge-handles";
+
+function firstStringSource(edge: EdgeHandle<string>): string {
+  const first = Object.values(edge.source)[0];
+  const v = first?.value();
+  return typeof v === "string" ? v : "";
+}
+
+export function upper(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() =>
+    edge.change(firstStringSource(edge).toUpperCase())
+  );
+}
+
+export function lower(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() =>
+    edge.change(firstStringSource(edge).toLowerCase())
+  );
+}
+
+export function slugify(edge: EdgeHandle<string>): () => void {
+  return edge.onAnyChange(() =>
+    edge.change(
+      firstStringSource(edge)
+        .toLowerCase()
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    )
+  );
+}

--- a/tools/edge-handles/src/wired-space-tool.tsx
+++ b/tools/edge-handles/src/wired-space-tool.tsx
@@ -1,0 +1,1669 @@
+/**
+ * Wired-space — a spatial dataflow canvas built on `edge-handles`.
+ *
+ * Each doc becomes a Card. Each EdgeHandle becomes a node hovering between
+ * its sources (on the left) and its targets (on the right). Wires connect
+ * card-ports to the node and back out again. Endpoint paths live in small
+ * badges at the connection point — hover to reveal, click to edit.
+ *
+ * Persisted state (on the folder doc):
+ *
+ *   folder.wiredSpace = {
+ *     positions:  { [docUrl]: { x, y, w, h } }
+ *     cardTools:  { [docUrl]: string }
+ *     edges:      AutomergeUrl[]
+ *     bindings:   { [edgeUrl]: { transformId } }
+ *   }
+ *
+ * Reactivity model:
+ *  - `watchDoc(handle)` returns a Solid signal whose value is the current
+ *    doc snapshot. The signal re-emits on every `handle.on("change")`. This
+ *    is coarser-grained than `makeDocumentProjection`, but bypasses a bug in
+ *    automerge-repo-solid-primitives whose `applyDelPatch` throws on map-key
+ *    deletions (so projections silently desync when you delete endpoints).
+ *  - Per-edge runtime state (the live `EdgeHandle`, its doc accessor, its
+ *    transform detach) is held in a `Map<url, LiveEdge>` exposed as a
+ *    `createSignal` so adds/removes propagate to JSX cleanly.
+ */
+
+import type {
+  AutomergeUrl,
+  DocHandle,
+  RefUrl,
+  Repo,
+} from "@automerge/automerge-repo";
+import {
+  getRegistry,
+  type Plugin,
+  type Tool,
+  type ToolElement,
+  type ToolDescription,
+} from "@inkandswitch/patchwork-plugins";
+import type { FolderDoc, DocLink } from "@inkandswitch/patchwork-filesystem";
+import {
+  createEdgeHandle,
+  findEdgeHandle,
+  type EdgeHandle,
+  type EdgeHandleDoc,
+  type HandleUrl,
+} from "@inkandswitch/edge-handles";
+import * as patterns from "./patterns/index.js";
+import {
+  For,
+  Show,
+  createMemo,
+  createSignal,
+  createEffect,
+  onCleanup,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { render } from "solid-js/web";
+
+// ─── constants ────────────────────────────────────────────────────────────
+
+const DEFAULT_W = 280;
+const DEFAULT_H = 220;
+const MIN_W = 140;
+const MIN_H = 100;
+const GRID_GAP = 24;
+const COLS = 3;
+const NODE_W = 140;
+const NODE_H = 32;
+
+const COLOR_ACCENT = "rgba(120,140,255,0.9)";
+const COLOR_ACCENT_BG = "rgba(120,140,200,0.08)";
+const COLOR_ACCENT_BORDER = "rgba(120,140,200,0.32)";
+const COLOR_INK = "rgba(60,70,100,0.85)";
+const COLOR_INK_DIM = "rgba(80,90,160,0.85)";
+const FONT_UI =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif";
+const FONT_MONO = "ui-monospace,SFMono-Regular,Menlo,monospace";
+
+const TRANSFORMS: Record<string, (edge: EdgeHandle<any>) => () => void> = {
+  identity: patterns.identity,
+  "math/sum": patterns.sum,
+  "text/upper": patterns.upper,
+  "text/lower": patterns.lower,
+  "text/slugify": patterns.slugify,
+  "text/markdown-to-html": patterns.markdownToHtml,
+  "color/srgb-to-oklch": patterns.srgbToOklch,
+  "color/oklch-to-srgb": patterns.oklchToSrgb,
+};
+const TRANSFORM_IDS = Object.keys(TRANSFORMS).sort();
+
+// ─── types ────────────────────────────────────────────────────────────────
+
+interface Point {
+  x: number;
+  y: number;
+}
+interface CardPos {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+interface WiredSpaceState {
+  positions?: Record<string, CardPos>;
+  cardTools?: Record<string, string>;
+  edges?: AutomergeUrl[];
+  bindings?: Record<string, { transformId: string }>;
+}
+type FolderDocWithWiredSpace = FolderDoc & { wiredSpace?: WiredSpaceState };
+
+interface LiveEdge {
+  url: AutomergeUrl;
+  edge: EdgeHandle<unknown>;
+  doc: Accessor<EdgeHandleDoc>;
+  detach: (() => void) | null;
+  transformId: string;
+}
+
+type DragKind = "card-out" | "node-out";
+interface DragOrigin {
+  kind: DragKind;
+  /** Source card URL or source edge URL. */
+  refId: string;
+  /** Canvas-space origin point for the in-flight wire. */
+  origin: Point;
+}
+
+type DropTarget =
+  | { kind: "card"; refId: string }
+  | { kind: "node"; refId: string };
+
+interface InspectorState {
+  edgeUrl: AutomergeUrl;
+  x: number;
+  y: number;
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to a DocHandle and expose its current doc as a Solid signal.
+ *
+ * Replaces `makeDocumentProjection` — which has a bug applying `del` patches
+ * to maps and silently desyncs on endpoint/cardTool deletions. Coarser
+ * granularity (every change re-runs every consumer) is fine for our docs.
+ */
+function watchDoc<T>(handle: DocHandle<T>): Accessor<T> {
+  const [doc, setDoc] = createSignal<T>(handle.doc() as T, { equals: false });
+  const update = () => setDoc(() => handle.doc() as T);
+  handle.on("change", update);
+  onCleanup(() => handle.off("change", update));
+  return doc;
+}
+
+function docIdOf(url: string): string | undefined {
+  const m = /^automerge:([^/#]+)/.exec(url);
+  return m ? m[1] : undefined;
+}
+
+function pathOfUrl(url: string): string {
+  const m = /^automerge:[^/#]+\/([^#]*)/.exec(url);
+  return m ? m[1] : "";
+}
+
+function refUrl(docUrl: AutomergeUrl, path: string): HandleUrl {
+  if (!path) return docUrl;
+  const id = docIdOf(docUrl);
+  if (!id) return docUrl;
+  return `automerge:${id}/${path}` as RefUrl;
+}
+
+function shortUrl(url: string): string {
+  if (url.length <= 20) return url;
+  return `${url.slice(0, 12)}…${url.slice(-6)}`;
+}
+
+function shortDoc(url: string): string {
+  const id = docIdOf(url) ?? "";
+  return id.length <= 10 ? id : `${id.slice(0, 6)}…${id.slice(-4)}`;
+}
+
+function cubicPath(a: Point, b: Point): string {
+  const dx = Math.max(40, Math.abs(b.x - a.x) / 2);
+  return `M ${a.x} ${a.y} C ${a.x + dx} ${a.y}, ${b.x - dx} ${b.y}, ${b.x} ${b.y}`;
+}
+
+function slugFor(base: string): string {
+  return (
+    base
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "") || "src"
+  );
+}
+
+function uniqueKey(base: string, existing: string[] = []): string {
+  if (!existing.includes(base)) return base;
+  let i = 2;
+  while (existing.includes(`${base}_${i}`)) i += 1;
+  return `${base}_${i}`;
+}
+
+function fieldFor(handle: DocHandle<any>): string {
+  const doc = handle.doc() as Record<string, unknown> | undefined;
+  if (!doc) return "content";
+  if ("content" in doc) return "content";
+  if ("value" in doc) return "value";
+  if ("body" in doc) return "body";
+  if ("text" in doc) return "text";
+  return "";
+}
+
+function linkName(links: DocLink[], url: string): string | undefined {
+  return links.find((l) => l.url === url)?.name;
+}
+
+function listToolsForType(type: string): ToolDescription[] {
+  const reg = getRegistry<ToolDescription>("patchwork:tool");
+  return reg.all().filter((t) => {
+    if (t.id === "wired-space" || t.id === "edge-pair") return false;
+    const sd = t.supportedDatatypes;
+    if (sd === "*") return true;
+    if (Array.isArray(sd)) return sd.includes(type) || sd.includes("*");
+    return false;
+  }) as ToolDescription[];
+}
+
+// ─── topological layout ───────────────────────────────────────────────────
+
+/**
+ * Lay cards out by their depth in the edge DAG: sources on the left, sinks on
+ * the right. Each column is vertically centered against the tallest column,
+ * and the horizontal stride leaves room for the edge node between columns.
+ * Back-edges (cycles) are broken by visiting order.
+ */
+function computeTopologicalLayout(
+  links: DocLink[],
+  edgeUrls: AutomergeUrl[],
+  edgeDocOf: (url: AutomergeUrl) => EdgeHandleDoc | undefined
+): Record<string, CardPos> {
+  const idToUrl = new Map<string, string>();
+  for (const l of links) {
+    const id = docIdOf(l.url);
+    if (id) idToUrl.set(id, l.url);
+  }
+
+  const adj = new Map<string, Set<string>>();
+  for (const l of links) adj.set(l.url, new Set());
+  for (const edgeUrl of edgeUrls) {
+    const doc = edgeDocOf(edgeUrl);
+    if (!doc) continue;
+    const sourceUrls = Object.values(doc.source ?? {});
+    const targetUrls = Object.values(doc.target ?? {});
+    for (const fu of sourceUrls) {
+      const fid = docIdOf(fu);
+      const f = fid ? idToUrl.get(fid) : undefined;
+      if (!f) continue;
+      for (const tu of targetUrls) {
+        const tid = docIdOf(tu);
+        const t = tid ? idToUrl.get(tid) : undefined;
+        if (!t) continue;
+        adj.get(f)?.add(t);
+      }
+    }
+  }
+
+  const depth = new Map<string, number>();
+  const visiting = new Set<string>();
+  function depthOf(u: string): number {
+    if (depth.has(u)) return depth.get(u)!;
+    if (visiting.has(u)) return 0;
+    visiting.add(u);
+    let d = 0;
+    for (const [v, outs] of adj.entries()) {
+      if (v !== u && outs.has(u)) d = Math.max(d, depthOf(v) + 1);
+    }
+    visiting.delete(u);
+    depth.set(u, d);
+    return d;
+  }
+  for (const l of links) depthOf(l.url);
+
+  const columns = new Map<number, string[]>();
+  for (const l of links) {
+    const d = depth.get(l.url) ?? 0;
+    if (!columns.has(d)) columns.set(d, []);
+    columns.get(d)!.push(l.url);
+  }
+
+  const colStride = DEFAULT_W + NODE_W + GRID_GAP * 2;
+  const tallestColumn = Math.max(
+    ...[...columns.values()].map((c) => c.length),
+    1
+  );
+  const baselineHeight =
+    tallestColumn * DEFAULT_H + (tallestColumn - 1) * GRID_GAP;
+
+  const out: Record<string, CardPos> = {};
+  const depths = [...columns.keys()].sort((a, b) => a - b);
+  for (const d of depths) {
+    const col = columns.get(d)!;
+    const colHeight = col.length * DEFAULT_H + (col.length - 1) * GRID_GAP;
+    const yOffset = GRID_GAP + (baselineHeight - colHeight) / 2;
+    col.forEach((url, i) => {
+      out[url] = {
+        x: GRID_GAP + d * colStride,
+        y: yOffset + i * (DEFAULT_H + GRID_GAP),
+        w: DEFAULT_W,
+        h: DEFAULT_H,
+      };
+    });
+  }
+  return out;
+}
+
+// ─── tool entry point ─────────────────────────────────────────────────────
+
+function renderWiredSpace(
+  handle: DocHandle<FolderDocWithWiredSpace>,
+  element: ToolElement
+): () => void {
+  return render(
+    () => <WiredSpace handle={handle} element={element} />,
+    element
+  );
+}
+
+export const wiredSpacePlugins: Plugin<any>[] = [
+  {
+    type: "patchwork:tool",
+    id: "wired-space",
+    name: "Wired Space",
+    icon: "Network",
+    supportedDatatypes: ["folder"],
+    async load() {
+      return renderWiredSpace;
+    },
+  } satisfies Tool<FolderDocWithWiredSpace>,
+];
+
+// ─── main component ───────────────────────────────────────────────────────
+
+function WiredSpace(props: {
+  handle: DocHandle<FolderDocWithWiredSpace>;
+  element: ToolElement;
+}): JSX.Element {
+  const { handle, element } = props;
+  const repo: Repo = element.repo;
+
+  // Reactive folder doc.
+  const folder = watchDoc<FolderDocWithWiredSpace>(handle);
+
+  // Live edge runtime state, keyed by edge URL. Replaced (not mutated) on
+  // add/remove so Solid sees a fresh value.
+  const [liveEdges, setLiveEdges] = createSignal<
+    ReadonlyMap<AutomergeUrl, LiveEdge>
+  >(new Map());
+  const setLiveEdge = (url: AutomergeUrl, live: LiveEdge) =>
+    setLiveEdges((m) => new Map(m).set(url, live));
+  const removeLiveEdge = (url: AutomergeUrl) =>
+    setLiveEdges((m) => {
+      const next = new Map(m);
+      next.delete(url);
+      return next;
+    });
+
+  // Drag state.
+  const [drag, setDrag] = createSignal<DragOrigin | null>(null);
+  const [cursor, setCursor] = createSignal<Point | null>(null);
+
+  // Inspector state.
+  const [inspector, setInspector] = createSignal<InspectorState | null>(null);
+
+  // ─── derived: cards ────────────────────────────────────────────────────
+  const cardLinks = createMemo<DocLink[]>(() =>
+    (folder().docs ?? []).filter((l) => l.type !== "folder")
+  );
+
+  const cardPosOf = (url: string): CardPos => {
+    const p = folder().wiredSpace?.positions?.[url];
+    if (p) return p;
+    const links = cardLinks();
+    const i = links.findIndex((l) => l.url === url);
+    return {
+      x: GRID_GAP + (i % COLS) * (DEFAULT_W + GRID_GAP),
+      y: GRID_GAP + Math.floor(i / COLS) * (DEFAULT_H + GRID_GAP),
+      w: DEFAULT_W,
+      h: DEFAULT_H,
+    };
+  };
+
+  const cardToolOf = (url: string): string | undefined =>
+    folder().wiredSpace?.cardTools?.[url];
+
+  // ─── derived: anchors and centroids ────────────────────────────────────
+  // Resolve a wire endpoint URL → canvas point. Card endpoint = the card's
+  // right/left edge midpoint. Edge endpoint (chaining) = the node's right/
+  // left edge midpoint.
+  function anchorForEndpoint(
+    url: string,
+    side: "out" | "in"
+  ): Point | undefined {
+    const docId = docIdOf(url);
+    if (!docId) return undefined;
+    const link = cardLinks().find((l) => l.url.endsWith(docId));
+    if (link) {
+      const p = cardPosOf(link.url);
+      return side === "out"
+        ? { x: p.x + p.w, y: p.y + p.h / 2 }
+        : { x: p.x, y: p.y + p.h / 2 };
+    }
+    for (const [edgeUrl, live] of liveEdges()) {
+      if (edgeUrl.endsWith(docId)) {
+        const c = centroidOf(live.doc());
+        if (!c) continue;
+        return side === "out"
+          ? { x: c.x + NODE_W / 2, y: c.y }
+          : { x: c.x - NODE_W / 2, y: c.y };
+      }
+    }
+    return undefined;
+  }
+
+  // Edge node sits at the horizontal midpoint of its endpoint anchors and at
+  // the vertical average — splits sources from targets cleanly while sitting
+  // along the natural flow.
+  function centroidOf(doc: EdgeHandleDoc): Point | undefined {
+    const pts: Point[] = [];
+    for (const u of Object.values(doc.source ?? {})) {
+      const p = anchorForEndpoint(u, "out");
+      if (p) pts.push(p);
+    }
+    for (const u of Object.values(doc.target ?? {})) {
+      const p = anchorForEndpoint(u, "in");
+      if (p) pts.push(p);
+    }
+    if (pts.length === 0) return undefined;
+    const xs = pts.map((p) => p.x);
+    const x = (Math.min(...xs) + Math.max(...xs)) / 2;
+    const y = pts.reduce((s, p) => s + p.y, 0) / pts.length;
+    return { x, y };
+  }
+
+  // ─── edge reconciliation ───────────────────────────────────────────────
+  // Open EdgeHandles for every URL in the folder; tear down on removal.
+  createEffect(() => {
+    const urls = folder().wiredSpace?.edges ?? [];
+    const wanted = new Set(urls);
+
+    for (const [url, live] of liveEdges()) {
+      if (!wanted.has(url)) {
+        live.detach?.();
+        live.edge.destroy();
+        removeLiveEdge(url);
+      }
+    }
+
+    for (const url of urls) {
+      if (liveEdges().has(url)) continue;
+      const transformId =
+        folder().wiredSpace?.bindings?.[url]?.transformId ?? "identity";
+      void (async () => {
+        try {
+          const edge = await findEdgeHandle(repo, url);
+          const docSig = watchDoc<EdgeHandleDoc>(edge.doc);
+          const attach = TRANSFORMS[transformId];
+          const detach = attach ? attach(edge) : null;
+          setLiveEdge(url, {
+            url,
+            edge,
+            doc: docSig,
+            detach,
+            transformId,
+          });
+        } catch (err) {
+          console.error("[wired-space] failed to open edge", url, err);
+        }
+      })();
+    }
+  });
+
+  // Re-attach transforms when bindings change.
+  createEffect(() => {
+    const bindings = folder().wiredSpace?.bindings ?? {};
+    for (const [url, live] of liveEdges()) {
+      const wanted = bindings[url]?.transformId ?? "identity";
+      if (live.transformId === wanted) continue;
+      live.detach?.();
+      const attach = TRANSFORMS[wanted];
+      const detach = attach ? attach(live.edge) : null;
+      setLiveEdge(url, { ...live, detach, transformId: wanted });
+    }
+  });
+
+  onCleanup(() => {
+    for (const live of liveEdges().values()) {
+      live.detach?.();
+      live.edge.destroy();
+    }
+  });
+
+  // ─── mutators ──────────────────────────────────────────────────────────
+  const editFolder = (fn: (s: WiredSpaceState) => void) =>
+    handle.change((d) => {
+      if (!d.wiredSpace) d.wiredSpace = {};
+      fn(d.wiredSpace);
+    });
+
+  const setCardPos = (url: string, next: CardPos) =>
+    editFolder((s) => {
+      if (!s.positions) s.positions = {};
+      s.positions[url] = next;
+    });
+
+  const setCardTool = (url: string, tid: string) =>
+    editFolder((s) => {
+      if (!s.cardTools) s.cardTools = {};
+      if (tid === "") delete s.cardTools[url];
+      else s.cardTools[url] = tid;
+    });
+
+  const setBinding = (edgeUrl: string, transformId: string) =>
+    editFolder((s) => {
+      if (!s.bindings) s.bindings = {};
+      s.bindings[edgeUrl] = { transformId };
+    });
+
+  const removeEdge = (edgeUrl: string) =>
+    editFolder((s) => {
+      if (s.edges) s.edges = s.edges.filter((u) => u !== edgeUrl);
+      if (s.bindings) delete s.bindings[edgeUrl];
+    });
+
+  async function createWireBetween(fromDocUrl: string, toDocUrl: string) {
+    const [fromH, toH] = await Promise.all([
+      repo.find(fromDocUrl as AutomergeUrl),
+      repo.find(toDocUrl as AutomergeUrl),
+    ]);
+    await Promise.all([fromH.whenReady(), toH.whenReady()]);
+    const fromName = uniqueKey(
+      slugFor(linkName(cardLinks(), fromDocUrl) ?? "src")
+    );
+    const toName = uniqueKey(
+      slugFor(linkName(cardLinks(), toDocUrl) ?? "sink")
+    );
+    const edge = await createEdgeHandle(repo, {
+      source: {
+        [fromName]: refUrl(fromH.url as AutomergeUrl, fieldFor(fromH)),
+      },
+      target: {
+        [toName]: refUrl(toH.url as AutomergeUrl, fieldFor(toH)),
+      },
+    });
+    editFolder((s) => {
+      if (!s.edges) s.edges = [];
+      s.edges.push(edge.url);
+      if (!s.bindings) s.bindings = {};
+      s.bindings[edge.url] = { transformId: "identity" };
+    });
+  }
+
+  async function addSourceToEdge(
+    edgeUrl: AutomergeUrl,
+    sourceDocUrl: string
+  ) {
+    const fromH = await repo.find(sourceDocUrl as AutomergeUrl);
+    await fromH.whenReady();
+    const edge = await findEdgeHandle(repo, edgeUrl);
+    const name = uniqueKey(
+      slugFor(linkName(cardLinks(), sourceDocUrl) ?? "src"),
+      Object.keys(edge.doc.doc()?.source ?? {})
+    );
+    edge.setSource(name, refUrl(fromH.url as AutomergeUrl, fieldFor(fromH)));
+  }
+
+  async function addTargetToEdge(edgeUrl: AutomergeUrl, toDocUrl: string) {
+    const toH = await repo.find(toDocUrl as AutomergeUrl);
+    await toH.whenReady();
+    const edge = await findEdgeHandle(repo, edgeUrl);
+    const name = uniqueKey(
+      slugFor(linkName(cardLinks(), toDocUrl) ?? "sink"),
+      Object.keys(edge.doc.doc()?.target ?? {})
+    );
+    edge.setTarget(name, refUrl(toH.url as AutomergeUrl, fieldFor(toH)));
+  }
+
+  async function addSourceEdgeToEdge(
+    targetEdgeUrl: AutomergeUrl,
+    sourceEdgeUrl: AutomergeUrl
+  ) {
+    const edge = await findEdgeHandle(repo, targetEdgeUrl);
+    const name = uniqueKey(
+      "edge",
+      Object.keys(edge.doc.doc()?.source ?? {})
+    );
+    edge.setSource(name, sourceEdgeUrl);
+  }
+
+  function layoutGrid() {
+    editFolder((s) => {
+      s.positions = computeTopologicalLayout(
+        cardLinks(),
+        s.edges ?? [],
+        (edgeUrl) => liveEdges().get(edgeUrl)?.doc()
+      );
+    });
+  }
+
+  // ─── drag-to-wire state machine ────────────────────────────────────────
+  let layerEl: HTMLDivElement | undefined;
+  const canvasPoint = (clientX: number, clientY: number): Point => {
+    if (!layerEl) return { x: clientX, y: clientY };
+    const r = layerEl.getBoundingClientRect();
+    return { x: clientX - r.left, y: clientY - r.top };
+  };
+
+  function dropTargetAt(clientX: number, clientY: number): DropTarget | null {
+    const target = document.elementFromPoint(clientX, clientY);
+    if (!(target instanceof HTMLElement)) return null;
+    const cardEl = target.closest<HTMLElement>("[data-card-url]");
+    if (cardEl) return { kind: "card", refId: cardEl.dataset.cardUrl! };
+    const nodeEl = target.closest<HTMLElement>("[data-edge-url]");
+    if (nodeEl) return { kind: "node", refId: nodeEl.dataset.edgeUrl! };
+    return null;
+  }
+
+  // `originViewport` is the on-screen port center; we convert to canvas
+  // coords internally so the in-flight wire actually anchors to the port.
+  function startDrag(
+    kind: DragKind,
+    refId: string,
+    ev: PointerEvent,
+    originViewport: Point
+  ) {
+    ev.stopPropagation();
+    setDrag({
+      kind,
+      refId,
+      origin: canvasPoint(originViewport.x, originViewport.y),
+    });
+    setCursor(canvasPoint(ev.clientX, ev.clientY));
+    document.body.style.userSelect = "none";
+
+    const onMove = (m: PointerEvent) =>
+      setCursor(canvasPoint(m.clientX, m.clientY));
+    const onUp = (u: PointerEvent) => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.body.style.userSelect = "";
+      const target = dropTargetAt(u.clientX, u.clientY);
+      const d = drag();
+      setDrag(null);
+      setCursor(null);
+      if (target && d) void completeDrag(d, target);
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+  }
+
+  async function completeDrag(d: DragOrigin, target: DropTarget) {
+    if (d.kind === "card-out" && target.kind === "card") {
+      if (d.refId === target.refId) return;
+      await createWireBetween(d.refId, target.refId);
+    } else if (d.kind === "card-out" && target.kind === "node") {
+      await addSourceToEdge(target.refId as AutomergeUrl, d.refId);
+    } else if (d.kind === "node-out" && target.kind === "card") {
+      await addTargetToEdge(d.refId as AutomergeUrl, target.refId);
+    } else if (d.kind === "node-out" && target.kind === "node") {
+      if (d.refId === target.refId) return;
+      await addSourceEdgeToEdge(
+        target.refId as AutomergeUrl,
+        d.refId as AutomergeUrl
+      );
+    }
+  }
+
+  // ─── inspector helpers ─────────────────────────────────────────────────
+  const openInspector = (edgeUrl: AutomergeUrl, ev: MouseEvent) =>
+    setInspector({ edgeUrl, x: ev.clientX, y: ev.clientY });
+
+  const onClickWire = (
+    ev: MouseEvent,
+    live: LiveEdge,
+    side: "source" | "target",
+    name: string
+  ) => {
+    ev.stopPropagation();
+    if (ev.altKey) {
+      if (side === "source") live.edge.removeSource(name);
+      else live.edge.removeTarget(name);
+    } else {
+      openInspector(live.url, ev);
+    }
+  };
+
+  // Close inspector when clicking outside it (but not on wires/nodes/badges).
+  const onBackgroundClick = (ev: MouseEvent) => {
+    const t = ev.target;
+    if (!inspector()) return;
+    if (
+      t instanceof HTMLElement &&
+      (t.closest("[data-inspector]") ||
+        t.closest("[data-edge-url]") ||
+        t.closest("[data-endpoint-badge]"))
+    )
+      return;
+    if (t instanceof Element && t.closest('[data-wire="1"]')) return;
+    setInspector(null);
+  };
+
+  // ─── render ────────────────────────────────────────────────────────────
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+        background: "var(--color-base-100, #f3f5fa)",
+        display: "grid",
+        "grid-template-rows": "auto 1fr",
+        "font-family": FONT_UI,
+      }}
+      onClick={onBackgroundClick}
+    >
+      <Toolbar
+        onLayout={layoutGrid}
+        onClear={() =>
+          editFolder((s) => {
+            s.edges = [];
+            s.bindings = {};
+          })
+        }
+        statusText={() => (drag() ? "drop on a card or node" : "")}
+      />
+
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+          "min-height": 0,
+          overflow: "auto",
+        }}
+      >
+        <div
+          ref={layerEl}
+          style={{
+            position: "relative",
+            width: "4000px",
+            height: "3000px",
+          }}
+        >
+          <WiresLayer
+            liveEdges={liveEdges}
+            anchorForEndpoint={anchorForEndpoint}
+            drag={drag}
+            cursor={cursor}
+            onClickWire={onClickWire}
+          />
+
+          <For each={cardLinks()}>
+            {(link) => (
+              <Card
+                link={link}
+                pos={() => cardPosOf(link.url)}
+                toolId={() => cardToolOf(link.url)}
+                wiringActive={() => drag() !== null}
+                onPos={(next) => setCardPos(link.url, next)}
+                onTool={(tid) => setCardTool(link.url, tid)}
+                onOutPointerDown={(ev, origin) =>
+                  startDrag("card-out", link.url, ev, origin)
+                }
+              />
+            )}
+          </For>
+
+          <For each={[...liveEdges().values()]}>
+            {(live) => (
+              <EdgeNode
+                live={live}
+                centroid={() => centroidOf(live.doc())}
+                wiringActive={() => drag() !== null}
+                onStartDrag={(ev, rect) =>
+                  startDrag("node-out", live.url, ev, {
+                    x: rect.right,
+                    y: rect.top + rect.height / 2,
+                  })
+                }
+                onOpenInspector={(ev) => openInspector(live.url, ev)}
+              />
+            )}
+          </For>
+
+          <For each={[...liveEdges().values()]}>
+            {(live) => (
+              <EndpointBadges
+                live={live}
+                anchorForEndpoint={anchorForEndpoint}
+              />
+            )}
+          </For>
+        </div>
+      </div>
+
+      <Show when={inspector()}>
+        {(insp) => {
+          const live = createMemo(() => liveEdges().get(insp().edgeUrl));
+          return (
+            <Show when={live()}>
+              {(l) => (
+                <Inspector
+                  live={l}
+                  position={() => ({ x: insp().x, y: insp().y })}
+                  elementRect={() => element.getBoundingClientRect()}
+                  onTransform={(tid) => setBinding(insp().edgeUrl, tid)}
+                  onRemoveEdge={() => {
+                    removeEdge(insp().edgeUrl);
+                    setInspector(null);
+                  }}
+                  onClose={() => setInspector(null)}
+                />
+              )}
+            </Show>
+          );
+        }}
+      </Show>
+    </div>
+  );
+}
+
+// ─── sub-components: Toolbar ──────────────────────────────────────────────
+
+function Toolbar(props: {
+  onLayout: () => void;
+  onClear: () => void;
+  statusText: () => string;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        display: "flex",
+        "align-items": "center",
+        gap: "6px",
+        padding: "6px 10px",
+        "border-bottom": "1px solid rgba(120,140,200,0.18)",
+        "font-size": "12px",
+        background: "rgba(255,255,255,0.6)",
+      }}
+    >
+      <span
+        style={{
+          "font-weight": 600,
+          color: COLOR_INK_DIM,
+          "margin-right": "8px",
+        }}
+      >
+        wired-space
+      </span>
+      <ToolbarButton label="Layout" onClick={props.onLayout} />
+      <ToolbarButton label="Clear wires" onClick={props.onClear} />
+      <span style={{ opacity: 0.55, "margin-left": "4px" }}>
+        Drag a card's right port onto another's left to connect. Hover a wire
+        endpoint to see its path; click to edit, alt+click to detach.
+      </span>
+      <span
+        style={{
+          "margin-left": "auto",
+          "font-family": FONT_MONO,
+          "font-size": "10px",
+          opacity: 0.55,
+          "white-space": "nowrap",
+        }}
+      >
+        {props.statusText()}
+      </span>
+    </div>
+  );
+}
+
+function ToolbarButton(props: {
+  label: string;
+  onClick: () => void;
+}): JSX.Element {
+  return (
+    <button
+      style={{
+        "font-size": "11px",
+        padding: "2px 8px",
+        "margin-left": "4px",
+        "border-radius": "4px",
+        border: "1px solid rgba(120,140,200,0.4)",
+        background: "transparent",
+        color: "inherit",
+        cursor: "pointer",
+      }}
+      onClick={() => props.onClick()}
+    >
+      {props.label}
+    </button>
+  );
+}
+
+// ─── sub-components: Card ─────────────────────────────────────────────────
+
+function Card(props: {
+  link: DocLink;
+  pos: () => CardPos;
+  toolId: () => string | undefined;
+  wiringActive: () => boolean;
+  onPos: (next: CardPos) => void;
+  onTool: (tid: string) => void;
+  onOutPointerDown: (ev: PointerEvent, originViewport: Point) => void;
+}): JSX.Element {
+  let outPortEl: HTMLDivElement | undefined;
+
+  const onHeaderPointerDown = (ev: PointerEvent) => {
+    if (ev.target instanceof HTMLButtonElement) return;
+    if (ev.target instanceof HTMLSelectElement) return;
+    const start = props.pos();
+    const ox = ev.clientX - start.x;
+    const oy = ev.clientY - start.y;
+    document.body.style.userSelect = "none";
+    const onMove = (m: PointerEvent) =>
+      props.onPos({
+        ...props.pos(),
+        x: Math.max(0, m.clientX - ox),
+        y: Math.max(0, m.clientY - oy),
+      });
+    const onUp = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+  };
+
+  const onResizePointerDown = (ev: PointerEvent) => {
+    ev.stopPropagation();
+    const start = props.pos();
+    const sx = ev.clientX;
+    const sy = ev.clientY;
+    document.body.style.userSelect = "none";
+    const onMove = (m: PointerEvent) =>
+      props.onPos({
+        ...props.pos(),
+        w: Math.max(MIN_W, start.w + (m.clientX - sx)),
+        h: Math.max(MIN_H, start.h + (m.clientY - sy)),
+      });
+    const onUp = () => {
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+      document.body.style.userSelect = "";
+    };
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+  };
+
+  return (
+    <div
+      data-card-url={props.link.url}
+      style={{
+        position: "absolute",
+        left: `${props.pos().x}px`,
+        top: `${props.pos().y}px`,
+        width: `${props.pos().w}px`,
+        height: `${props.pos().h}px`,
+        background: "white",
+        border: `1px solid ${COLOR_ACCENT_BORDER}`,
+        "border-radius": "8px",
+        "box-shadow": "0 2px 8px rgba(50,60,90,0.08)",
+        display: "flex",
+        "flex-direction": "column",
+        overflow: "visible",
+        "min-width": `${MIN_W}px`,
+        "min-height": `${MIN_H}px`,
+      }}
+    >
+      <div
+        onPointerDown={onHeaderPointerDown}
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "6px",
+          padding: "4px 8px",
+          background: COLOR_ACCENT_BG,
+          "border-bottom": "1px solid rgba(120,140,200,0.18)",
+          "font-size": "11px",
+          color: COLOR_INK,
+          "user-select": "none",
+          cursor: "move",
+          "border-top-left-radius": "8px",
+          "border-top-right-radius": "8px",
+        }}
+      >
+        <span
+          style={{
+            flex: 1,
+            "white-space": "nowrap",
+            overflow: "hidden",
+            "text-overflow": "ellipsis",
+          }}
+        >
+          {props.link.name} · {props.link.type}
+        </span>
+        <ToolPicker
+          link={props.link}
+          value={props.toolId}
+          onChange={(tid) => props.onTool(tid)}
+        />
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          "min-height": 0,
+          "min-width": 0,
+          overflow: "hidden",
+          "border-bottom-left-radius": "8px",
+          "border-bottom-right-radius": "8px",
+        }}
+      >
+        {/* @ts-expect-error custom element */}
+        <patchwork-view
+          attr:doc-url={props.link.url}
+          attr:tool-id={props.toolId() || undefined}
+          style="width:100%;height:100%;display:flex;"
+        />
+      </div>
+
+      <Port
+        ref={outPortEl}
+        position="right"
+        kind="card-out"
+        visible={() => true}
+        onPointerDown={(ev) => {
+          if (!outPortEl) return;
+          const r = outPortEl.getBoundingClientRect();
+          props.onOutPointerDown(ev, {
+            x: r.left + r.width / 2,
+            y: r.top + r.height / 2,
+          });
+        }}
+      />
+
+      <Port position="left" kind="card-in" visible={props.wiringActive} />
+
+      <div
+        onPointerDown={onResizePointerDown}
+        style={{
+          position: "absolute",
+          right: 0,
+          bottom: 0,
+          width: "14px",
+          height: "14px",
+          cursor: "nwse-resize",
+          "z-index": 2,
+          "pointer-events": "auto",
+          background:
+            "linear-gradient(135deg, transparent 50%, rgba(120,140,200,0.55) 50%, rgba(120,140,200,0.55) 65%, transparent 65%, transparent 75%, rgba(120,140,200,0.55) 75%, rgba(120,140,200,0.55) 85%, transparent 85%)",
+        }}
+      />
+    </div>
+  );
+}
+
+function ToolPicker(props: {
+  link: DocLink;
+  value: () => string | undefined;
+  onChange: (id: string) => void;
+}): JSX.Element {
+  const options = createMemo(() =>
+    listToolsForType(props.link.type)
+      .map((t) => t.id)
+      .sort()
+  );
+  return (
+    <select
+      onChange={(e) => props.onChange(e.currentTarget.value)}
+      value={props.value() ?? ""}
+      style={{
+        "font-size": "10px",
+        padding: "1px 2px",
+        "border-radius": "4px",
+        border: "1px solid rgba(120,140,200,0.4)",
+        background: "transparent",
+      }}
+    >
+      <option value="">(default)</option>
+      <For each={options()}>{(id) => <option value={id}>{id}</option>}</For>
+    </select>
+  );
+}
+
+function Port(props: {
+  ref?: HTMLDivElement;
+  position: "left" | "right";
+  kind: "card-out" | "card-in";
+  visible: () => boolean;
+  onPointerDown?: (ev: PointerEvent) => void;
+}): JSX.Element {
+  const isInput = props.kind === "card-in";
+  return (
+    <div
+      ref={props.ref}
+      data-port-kind={props.kind}
+      onPointerDown={(ev) => props.onPointerDown?.(ev)}
+      style={{
+        position: "absolute",
+        [props.position]: "-6px",
+        top: "50%",
+        transform: "translate(0, -50%)",
+        width: "14px",
+        height: "10px",
+        "border-radius": "6px",
+        background: COLOR_ACCENT,
+        border: "1px solid rgba(120,140,255,0.95)",
+        "box-shadow": "0 1px 2px rgba(50,60,90,0.15)",
+        cursor: isInput ? "default" : "crosshair",
+        "pointer-events": "auto",
+        opacity: props.visible() ? 1 : 0,
+        transition: isInput ? "opacity 0.08s ease" : "none",
+        "z-index": 2,
+      }}
+    />
+  );
+}
+
+// ─── sub-components: EdgeNode ─────────────────────────────────────────────
+
+function EdgeNode(props: {
+  live: LiveEdge;
+  centroid: () => Point | undefined;
+  wiringActive: () => boolean;
+  onStartDrag: (ev: PointerEvent, rect: DOMRect) => void;
+  onOpenInspector: (ev: MouseEvent) => void;
+}): JSX.Element {
+  let nodeEl: HTMLDivElement | undefined;
+  let downAt: { x: number; y: number } | null = null;
+  const onDown = (ev: PointerEvent) => {
+    if (!nodeEl) return;
+    downAt = { x: ev.clientX, y: ev.clientY };
+    props.onStartDrag(ev, nodeEl.getBoundingClientRect());
+  };
+  const onUp = (ev: PointerEvent) => {
+    if (!downAt) return;
+    const dx = Math.abs(ev.clientX - downAt.x);
+    const dy = Math.abs(ev.clientY - downAt.y);
+    downAt = null;
+    if (dx < 3 && dy < 3) props.onOpenInspector(ev as unknown as MouseEvent);
+  };
+
+  return (
+    <Show when={props.centroid()}>
+      {(c) => (
+        <div
+          ref={nodeEl}
+          data-edge-url={props.live.url}
+          onPointerDown={onDown}
+          onPointerUp={onUp}
+          style={{
+            position: "absolute",
+            left: `${c().x - NODE_W / 2}px`,
+            top: `${c().y - NODE_H / 2}px`,
+            width: `${NODE_W}px`,
+            height: `${NODE_H}px`,
+            background: "rgba(255,255,255,0.94)",
+            border: "1.5px dashed rgba(120,140,255,0.8)",
+            "border-radius": "16px",
+            display: "flex",
+            "align-items": "center",
+            "justify-content": "center",
+            "font-size": "11px",
+            "line-height": 1,
+            "font-family": FONT_MONO,
+            color: "rgba(80,90,160,0.95)",
+            "user-select": "none",
+            cursor: props.wiringActive() ? "default" : "pointer",
+            "box-shadow": "0 2px 6px rgba(50,60,90,0.08)",
+            "z-index": 1,
+            padding: "0 10px",
+            "text-align": "center",
+            "white-space": "nowrap",
+            overflow: "hidden",
+            "text-overflow": "ellipsis",
+          }}
+        >
+          {props.live.transformId}
+        </div>
+      )}
+    </Show>
+  );
+}
+
+// ─── sub-components: EndpointBadges ───────────────────────────────────────
+
+/**
+ * Render a badge per `source`/`target` entry on this edge. Each badge is
+ * anchored at its wire's connection point on the card side.
+ */
+function EndpointBadges(props: {
+  live: LiveEdge;
+  anchorForEndpoint: (url: string, side: "out" | "in") => Point | undefined;
+}): JSX.Element {
+  const sourceEntries = createMemo(() =>
+    Object.entries(props.live.doc().source ?? {})
+  );
+  const targetEntries = createMemo(() =>
+    Object.entries(props.live.doc().target ?? {})
+  );
+
+  return (
+    <>
+      <For each={sourceEntries()}>
+        {([name, url]) => (
+          <EndpointBadge
+            pos={() => props.anchorForEndpoint(url, "out")}
+            url={url}
+            anchor="right"
+            onCommit={(next) => props.live.edge.setSource(name, next)}
+            onRemove={() => props.live.edge.removeSource(name)}
+          />
+        )}
+      </For>
+      <For each={targetEntries()}>
+        {([name, url]) => (
+          <EndpointBadge
+            pos={() => props.anchorForEndpoint(url, "in")}
+            url={url}
+            anchor="left"
+            onCommit={(next) => props.live.edge.setTarget(name, next)}
+            onRemove={() => props.live.edge.removeTarget(name)}
+          />
+        )}
+      </For>
+    </>
+  );
+}
+
+/**
+ * Per-endpoint badge floating at a wire's connection point.
+ * Idle:    tiny pill.
+ * Hover:   the endpoint's path becomes readable.
+ * Click (no drag): inline `<input>` for editing the path.
+ * Alt+click:       detaches this endpoint from the edge.
+ */
+function EndpointBadge(props: {
+  pos: () => Point | undefined;
+  url: string;
+  anchor: "left" | "right";
+  onCommit: (next: HandleUrl) => void;
+  onRemove: () => void;
+}): JSX.Element {
+  const [editing, setEditing] = createSignal(false);
+  const [hovered, setHovered] = createSignal(false);
+  const [draft, setDraft] = createSignal(pathOfUrl(props.url));
+  let inputEl: HTMLInputElement | undefined;
+
+  const labelText = createMemo(() => pathOfUrl(props.url) || "(root)");
+  const expanded = () => hovered() || editing();
+
+  const startEdit = () => {
+    setDraft(pathOfUrl(props.url));
+    setEditing(true);
+    queueMicrotask(() => inputEl?.focus());
+  };
+
+  const commit = () => {
+    const id = docIdOf(props.url);
+    if (!id) return setEditing(false);
+    const next = draft().trim();
+    const nextUrl = (next
+      ? (`automerge:${id}/${next}` as RefUrl)
+      : (`automerge:${id}` as AutomergeUrl)) as HandleUrl;
+    if (nextUrl !== props.url) props.onCommit(nextUrl);
+    setEditing(false);
+  };
+
+  // Click vs drag — we don't initiate any drag from here, but the canvas-level
+  // pointer handlers will treat movement-while-down as a drag, so we only
+  // open the editor if the pointer didn't move.
+  let downAt: { x: number; y: number } | null = null;
+  const onDown = (ev: PointerEvent) => {
+    ev.stopPropagation();
+    downAt = { x: ev.clientX, y: ev.clientY };
+  };
+  const onUp = (ev: PointerEvent) => {
+    if (!downAt) return;
+    const dx = Math.abs(ev.clientX - downAt.x);
+    const dy = Math.abs(ev.clientY - downAt.y);
+    downAt = null;
+    if (dx >= 4 || dy >= 4) return;
+    ev.stopPropagation();
+    if (ev.altKey) {
+      props.onRemove();
+      return;
+    }
+    if (!editing()) startEdit();
+  };
+
+  return (
+    <Show when={props.pos()}>
+      {(p) => (
+        <div
+          data-endpoint-badge="1"
+          onPointerDown={onDown}
+          onPointerUp={onUp}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          onClick={(ev) => ev.stopPropagation()}
+          title={
+            editing()
+              ? ""
+              : `${labelText()} (click to edit, alt+click to detach)`
+          }
+          style={{
+            position: "absolute",
+            left: `${p().x}px`,
+            top: `${p().y}px`,
+            transform:
+              props.anchor === "right"
+                ? "translate(0, -50%)"
+                : "translate(-100%, -50%)",
+            "z-index": 4,
+            "pointer-events": "auto",
+            display: "flex",
+            "align-items": "center",
+            padding: "1px 6px",
+            "border-radius": "10px",
+            background: expanded()
+              ? "rgba(255,255,255,0.96)"
+              : "rgba(120,140,255,0.85)",
+            color: expanded() ? COLOR_INK : "white",
+            border: "1px solid rgba(80,100,200,0.6)",
+            "box-shadow": expanded()
+              ? "0 1px 6px rgba(60,80,140,0.18)"
+              : "0 1px 2px rgba(50,60,90,0.2)",
+            "font-family": FONT_MONO,
+            "font-size": "10px",
+            "line-height": "1",
+            cursor: editing() ? "text" : "pointer",
+            "max-width": expanded() ? "200px" : "20px",
+            "min-width": "10px",
+            "min-height": "12px",
+            overflow: "hidden",
+            "white-space": "nowrap",
+            "text-overflow": "ellipsis",
+            transition: "max-width 0.12s ease, background 0.12s ease",
+            "user-select": "none",
+          }}
+        >
+          <Show
+            when={editing()}
+            fallback={
+              <span
+                style={{
+                  "white-space": "nowrap",
+                  overflow: "hidden",
+                  "text-overflow": "ellipsis",
+                }}
+              >
+                {expanded() ? labelText() : ""}
+              </span>
+            }
+          >
+            <input
+              ref={inputEl}
+              value={draft()}
+              placeholder="(root)"
+              onPointerDown={(ev) => ev.stopPropagation()}
+              onInput={(e) => setDraft(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  setEditing(false);
+                }
+              }}
+              onBlur={commit}
+              style={{
+                font: "inherit",
+                border: "none",
+                outline: "none",
+                background: "transparent",
+                padding: 0,
+                margin: 0,
+                width: "160px",
+                color: "inherit",
+              }}
+            />
+          </Show>
+        </div>
+      )}
+    </Show>
+  );
+}
+
+// ─── sub-components: WiresLayer ───────────────────────────────────────────
+
+function WiresLayer(props: {
+  liveEdges: () => ReadonlyMap<AutomergeUrl, LiveEdge>;
+  anchorForEndpoint: (url: string, side: "out" | "in") => Point | undefined;
+  drag: () => DragOrigin | null;
+  cursor: () => Point | null;
+  onClickWire: (
+    ev: MouseEvent,
+    live: LiveEdge,
+    side: "source" | "target",
+    name: string
+  ) => void;
+}): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="4000"
+      height="3000"
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: "4000px",
+        height: "3000px",
+        "pointer-events": "none",
+        overflow: "visible",
+      }}
+    >
+      <For each={[...props.liveEdges().values()]}>
+        {(live) => <EdgeWires live={live} {...props} />}
+      </For>
+      <Show when={props.drag() && props.cursor()}>
+        <path
+          d={cubicPath(props.drag()!.origin, props.cursor()!)}
+          stroke="rgba(120,140,255,0.85)"
+          stroke-width="2"
+          stroke-dasharray="4 3"
+          fill="none"
+        />
+      </Show>
+    </svg>
+  );
+}
+
+function EdgeWires(props: {
+  live: LiveEdge;
+  anchorForEndpoint: (url: string, side: "out" | "in") => Point | undefined;
+  onClickWire: (
+    ev: MouseEvent,
+    live: LiveEdge,
+    side: "source" | "target",
+    name: string
+  ) => void;
+}): JSX.Element {
+  const sourceEntries = createMemo(() =>
+    Object.entries(props.live.doc().source ?? {})
+  );
+  const targetEntries = createMemo(() =>
+    Object.entries(props.live.doc().target ?? {})
+  );
+  const centroid = createMemo<Point | undefined>(() => {
+    const pts: Point[] = [];
+    for (const u of Object.values(props.live.doc().source ?? {})) {
+      const p = props.anchorForEndpoint(u, "out");
+      if (p) pts.push(p);
+    }
+    for (const u of Object.values(props.live.doc().target ?? {})) {
+      const p = props.anchorForEndpoint(u, "in");
+      if (p) pts.push(p);
+    }
+    if (pts.length === 0) return undefined;
+    const xs = pts.map((p) => p.x);
+    return {
+      x: (Math.min(...xs) + Math.max(...xs)) / 2,
+      y: pts.reduce((s, p) => s + p.y, 0) / pts.length,
+    };
+  });
+
+  return (
+    <Show when={centroid()}>
+      {(c) => (
+        <>
+          <For each={sourceEntries()}>
+            {([name, url]) => {
+              const a = createMemo(() => props.anchorForEndpoint(url, "out"));
+              return (
+                <Show when={a()}>
+                  {(pt) => (
+                    <Wire
+                      from={pt()}
+                      to={{ x: c().x - NODE_W / 2, y: c().y }}
+                      onClick={(ev) =>
+                        props.onClickWire(ev, props.live, "source", name)
+                      }
+                    />
+                  )}
+                </Show>
+              );
+            }}
+          </For>
+          <For each={targetEntries()}>
+            {([name, url]) => {
+              const b = createMemo(() => props.anchorForEndpoint(url, "in"));
+              return (
+                <Show when={b()}>
+                  {(pt) => (
+                    <Wire
+                      from={{ x: c().x + NODE_W / 2, y: c().y }}
+                      to={pt()}
+                      onClick={(ev) =>
+                        props.onClickWire(ev, props.live, "target", name)
+                      }
+                    />
+                  )}
+                </Show>
+              );
+            }}
+          </For>
+        </>
+      )}
+    </Show>
+  );
+}
+
+function Wire(props: {
+  from: Point;
+  to: Point;
+  onClick: (ev: MouseEvent) => void;
+}): JSX.Element {
+  const d = createMemo(() => cubicPath(props.from, props.to));
+  return (
+    <>
+      <path
+        d={d()}
+        stroke={COLOR_ACCENT}
+        stroke-width="2"
+        fill="none"
+        data-wire="1"
+      />
+      <path
+        d={d()}
+        stroke="rgba(0,0,0,0)"
+        stroke-width="16"
+        fill="none"
+        data-wire="1"
+        style={{ cursor: "pointer", "pointer-events": "auto" }}
+        onClick={(ev) => props.onClick(ev)}
+      />
+    </>
+  );
+}
+
+// ─── sub-components: Inspector ────────────────────────────────────────────
+
+function Inspector(props: {
+  live: () => LiveEdge;
+  position: () => Point;
+  elementRect: () => DOMRect;
+  onTransform: (tid: string) => void;
+  onRemoveEdge: () => void;
+  onClose: () => void;
+}): JSX.Element {
+  const sourceNames = createMemo(() =>
+    Object.keys(props.live().doc().source ?? {})
+  );
+  const targetNames = createMemo(() =>
+    Object.keys(props.live().doc().target ?? {})
+  );
+
+  return (
+    <div
+      data-inspector="1"
+      style={{
+        position: "absolute",
+        "z-index": 10,
+        background: "white",
+        border: "1px solid rgba(120,140,200,0.4)",
+        "border-radius": "8px",
+        "box-shadow": "0 4px 16px rgba(60,80,140,0.18)",
+        padding: "10px",
+        "font-size": "11px",
+        "min-width": "260px",
+        "max-width": "320px",
+        left: `${props.position().x - props.elementRect().left + 10}px`,
+        top: `${props.position().y - props.elementRect().top + 10}px`,
+      }}
+    >
+      <div
+        style={{
+          "font-weight": 600,
+          "margin-bottom": "8px",
+          color: COLOR_INK,
+        }}
+      >
+        Edge {shortUrl(props.live().url)}
+      </div>
+
+      <RowLabel>Transform</RowLabel>
+      <select
+        value={props.live().transformId}
+        onChange={(e) => props.onTransform(e.currentTarget.value)}
+        style={{
+          "font-size": "11px",
+          padding: "2px 4px",
+          "border-radius": "4px",
+          border: "1px solid rgba(120,140,200,0.4)",
+          width: "100%",
+        }}
+      >
+        <For each={TRANSFORM_IDS}>
+          {(id) => <option value={id}>{id}</option>}
+        </For>
+      </select>
+
+      <RowLabel>
+        Sources ({sourceNames().length}) · Targets ({targetNames().length})
+      </RowLabel>
+      <div
+        style={{
+          "font-family": FONT_MONO,
+          "font-size": "10px",
+          color: "rgba(60,70,100,0.7)",
+          "line-height": 1.4,
+        }}
+      >
+        Hover the badges on the canvas to inspect each endpoint. Click to edit
+        a path; alt+click to detach.
+      </div>
+
+      <button
+        onClick={() => props.onRemoveEdge()}
+        style={{
+          "margin-top": "12px",
+          "font-size": "11px",
+          padding: "4px 8px",
+          "border-radius": "4px",
+          border: "1px solid rgba(180,80,80,0.5)",
+          background: "transparent",
+          color: "rgba(180,80,80,0.9)",
+          cursor: "pointer",
+          width: "100%",
+        }}
+      >
+        remove wire
+      </button>
+    </div>
+  );
+}
+
+function RowLabel(props: { children: JSX.Element }): JSX.Element {
+  return (
+    <div
+      style={{
+        "font-size": "10px",
+        "text-transform": "uppercase",
+        "letter-spacing": "0.04em",
+        color: "rgba(0,0,0,0.5)",
+        margin: "10px 0 4px",
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/tools/edge-handles/tsconfig.json
+++ b/tools/edge-handles/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNEXT",
+    "module": "ESNEXT",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ESNEXT", "DOM"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/tools/edge-handles/vite.config.ts
+++ b/tools/edge-handles/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+import external from "@inkandswitch/patchwork-bootloader/externals";
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: { external },
+    sourcemap: true,
+    target: "esnext",
+    minify: false,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/refs",
       "packages/annotations/core",
       "packages/annotations/context",
+      "packages/edge-handles",
     ],
   },
 });


### PR DESCRIPTION
We need a small, sharable primitive for doc-backed dataflow — something on which we can build transformers, propagators, workflows, and other pipelines without each one re-inventing wiring, persistence, and lifecycle. This PR adds an `EdgeHandle` primitive with a canonical serialized representation, which appears to be a reasonable sweet spot for general-purpose doc-backed reactivity/propagation.

- **`packages/edge-handles`**. No runtime deps beyond `@automerge/automerge-repo`
- **`tools/edge-handles`** — two patchwork tools (`edge-pair`, `wired-space`) and a `patterns/` library of simple test transforms (`identity`, `sum`, `template`, `markdownToHtml`, `srgbToOklch`/`oklchToSrgb`, `accumulator`, `streamed`, etc.).

`EdgeHandle` is **a doc-backed reactive cell with named upstream and downstream connections**. The doc holds the persistent wiring (`source` and `target` maps, plus an optional cached `value`); the class is its live in-memory presence. The cell runs no computation of its own — transforms are external code that subscribes to source/membership changes and writes back through `change()`.

The shape, condensed:

```ts
interface Handle<T = unknown> {
  readonly url: HandleUrl;
  value(): T;
  onChange(cb: (v: T) => void): () => void;
}
// Ref<T> and EdgeHandle<T> both implement Handle, so edges chain into edges.

class EdgeHandle<TValue = unknown> implements Handle<TValue | undefined> {
  readonly source: Record<string, Handle>;
  readonly target: Record<string, Handle>;
  readonly sourceErrors: Record<string, Error>;
  readonly targetErrors: Record<string, Error>;

  value(); change(fnOrValue);
  onValueChange(cb);
  onSourceChange((value, key) => …);   // per-source emit
  onMembersChange(() => …);            // membership (incl. initial)
  onAnyChange((value, key?) => …);     // sugar over both

  setSource(name, h); removeSource(name);
  setTarget(name, h); removeTarget(name);
  persisted();        setPersisted(on);
  destroy();
}

createEdgeHandle<T>(repo, init?);
findEdgeHandle<T>(repo, url);
```

EdgeHandles are serialized into documents with this shape
```ts
export interface EdgeHandleDoc {
  "@patchwork": { type: 'edge-handle'; version: 1 };
  /** Upstream handle URLs keyed by local name. */
  source: { [name: string]: HandleUrl };
  /** Downstream handle URLs keyed by local name. */
  target: { [name: string]: HandleUrl };
  /** When true, `change()` writes the value back to `value`. */
  persist?: boolean;
  /** Mirrored value when persistence is on. */
  value?: unknown;
}
```

A few choices worth flagging:
- **URLs are validated at edit time** (`isValidAutomergeUrl` plus a syntactic kind check). Mutators throw on malformed input.
- **Cycle safety at incomplete and at write time only.** A re-entrancy guard inside `change()` keeps cycles from blowing the stack. There is no edit-time cycle rejection — structurally cyclic graphs are allowed.