### PR TITLE
feat: add 'open-unsafe-modal' custom event

### DIFF
--- a/core/elements/src/events.ts
+++ b/core/elements/src/events.ts
@@ -17,6 +17,18 @@ export class OpenDocumentEvent extends CustomEvent<OpenDocumentEventDetail> {
   }
 }
 
+export type OpenUnsafeModalEventDetail = OpenDocumentEventDetail;
+
+export class OpenUnsafeModalEvent extends CustomEvent<OpenUnsafeModalEventDetail> {
+  constructor(detail: OpenUnsafeModalEventDetail) {
+    super("patchwork:open-unsafe-modal", {
+      detail,
+      composed: true,
+      bubbles: true,
+    });
+  }
+}
+
 export type MountedEventDetail =
   | { url: AutomergeUrl; toolId: string }
   | { componentId: string };
@@ -60,12 +72,14 @@ export class NoToolEvent extends CustomEvent<NoToolEventDetail> {
 declare global {
   interface ShadowRootEventMap extends ElementEventMap {
     "patchwork:open-document": OpenDocumentEvent;
+    "patchwork:open-unsafe-modal": OpenUnsafeModalEvent;
     "patchwork:mounted": MountedEvent;
     "patchwork:unmounted": UnmountedEvent;
     "patchwork:no-tool": NoToolEvent;
   }
   interface ElementEventMap {
     "patchwork:open-document": OpenDocumentEvent;
+    "patchwork:open-unsafe-modal": OpenUnsafeModalEvent;
     "patchwork:mounted": MountedEvent;
     "patchwork:unmounted": UnmountedEvent;
     "patchwork:no-tool": NoToolEvent;


### PR DESCRIPTION
In order to enable a frame within the forthcoming `patchwork-isolation` element, we need a way of opening tools that use the account document outside of the main document area. As a simple solution for now, I've added a new event to request opening a document in a modal with full access to the host context instead of the standard open-document, which in the isolation frame will always be in an isolated area where access to the account doc is blocked.

I don't particularly care about this name, but I do think we should have something that signals that using this is "unsafe" and should be a carefully considered choice, since that is how it will be used with the isolation context. 

This PR is accompanied by another [PR in patchwork-base](https://github.com/inkandswitch/patchwork-base/pull/11) where a new modal is added and the default frame/sidebar are updated to use it. These two PRs are a precursor to landing the rest of the isolation work.