### PR TITLE
import package descriptions in a worker

### DIFF
--- a/.changeset/worker-module-loader.md
+++ b/.changeset/worker-module-loader.md
@@ -1,0 +1,12 @@
+---
+"@inkandswitch/patchwork-filesystem": patch
+"@inkandswitch/patchwork-bootloader": patch
+---
+
+Discover a package's plugin descriptors in a dedicated module worker off the
+main thread, then re-import the package (pinned to the same heads) on the main
+thread to run each plugin's real loader. Adds
+`importPluginFromFolderDocUrl(folderDocUrl, pluginType, pluginId)`, which selects
+the plugin by both its `type` and `id` — a plugin `id` is only unique within a
+plugin type, so a package may export e.g. a `patchwork:datatype` and a
+`patchwork:tool` that share the same id.

--- a/core/bootloader/package.json
+++ b/core/bootloader/package.json
@@ -30,6 +30,10 @@
       "import": "./dist/automerge-worker.js",
       "types": "./dist/automerge-worker.d.ts"
     },
+    "./module-loader-worker": {
+      "import": "./dist/module-loader-worker.js",
+      "types": "./dist/module-loader-worker.d.ts"
+    },
     "./site": {
       "import": "./dist/site.js",
       "types": "./dist/site.d.ts"

--- a/core/bootloader/src/module-loader-worker.ts
+++ b/core/bootloader/src/module-loader-worker.ts
@@ -1,0 +1,68 @@
+// Dedicated module worker for plugin-descriptor discovery.
+//
+// A module-settings doc lists Automerge folder-doc packages. To register the
+// plugins a package provides we only need their *descriptions* (id, type,
+// name, icon…), not their implementations. This worker imports a package's
+// entry point off the main thread purely to read its exported `plugins` array,
+// strips the non-cloneable `load()` / `import` machinery, and posts the plain
+// descriptors back. The main thread re-imports the package (at the same heads)
+// only when a plugin is actually loaded — see `importPluginFromFolderDocUrl`.
+//
+// Created with type:"module"; its dynamic `import()` of `/<automergeUrl>/…`
+// entry points is served by the service worker that controls this worker.
+
+import { importModuleFromFolderDocUrl } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeUrl } from "@automerge/automerge-repo/slim";
+
+type DiscoverRequest = {
+  type: "discover";
+  id: number;
+  url: AutomergeUrl;
+};
+
+// Keep only the structured-cloneable description fields. `load` is a closure
+// and `module` is the (possibly already-loaded) implementation — neither can
+// cross the worker boundary. `import` is droppable too: the main thread
+// rebuilds loading by re-importing the package and calling the live plugin.
+function toDescriptor(plugin: any): Record<string, unknown> {
+  if (!plugin || typeof plugin !== "object") return {};
+  const { load, import: _import, module, ...description } = plugin;
+  return description;
+}
+
+function isDiscoverRequest(data: unknown): data is DiscoverRequest {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as any).type === "discover" &&
+    typeof (data as any).id === "number" &&
+    typeof (data as any).url === "string"
+  );
+}
+
+self.addEventListener("message", (event: MessageEvent) => {
+  const data = event.data;
+  if (!isDiscoverRequest(data)) return;
+  const { id, url } = data;
+
+  importModuleFromFolderDocUrl(url)
+    .then((mod) => {
+      const plugins: any[] = Array.isArray(mod?.plugins) ? mod.plugins : [];
+      const descriptors = plugins.map(toDescriptor);
+      (self as unknown as Worker).postMessage({
+        type: "descriptors",
+        id,
+        descriptors,
+      });
+    })
+    .catch((error) => {
+      (self as unknown as Worker).postMessage({
+        type: "error",
+        id,
+        error:
+          error instanceof Error
+            ? (error.stack ?? error.message)
+            : String(error),
+      });
+    });
+});

--- a/core/bootloader/src/module-loader.ts
+++ b/core/bootloader/src/module-loader.ts
@@ -1,0 +1,83 @@
+// Main-thread client for the module-loader worker (see module-loader-worker.ts).
+//
+// `importAutomergeModuleViaWorker` is wired into the ModuleWatcher in place of
+// its default (direct, main-thread) package import. It asks the worker to
+// import the package entry point and report which plugins it exports, then
+// returns the same `{ plugins }` shape the watcher already feeds to
+// `registerPlugins` — except each plugin's `load()` re-imports the package
+// (pinned to the same heads) on this thread and runs the real plugin loader.
+
+import { importPluginFromFolderDocUrl } from "@inkandswitch/patchwork-filesystem";
+import type { AutomergeUrl } from "@automerge/automerge-repo/slim";
+
+type Descriptor = Record<string, unknown> & { id?: string };
+
+type WorkerReply =
+  | { type: "descriptors"; id: number; descriptors: Descriptor[] }
+  | { type: "error"; id: number; error: string };
+
+const WORKER_PATH = "/module-loader-worker.js";
+
+let worker: Worker | undefined;
+let nextRequestId = 1;
+const pending = new Map<
+  number,
+  { resolve: (d: Descriptor[]) => void; reject: (e: Error) => void }
+>();
+
+function getWorker(): Worker {
+  if (worker) return worker;
+  worker = new Worker(WORKER_PATH, {
+    type: "module",
+    name: "patchwork-module-loader",
+  });
+  worker.addEventListener("message", (event: MessageEvent<WorkerReply>) => {
+    const data = event.data;
+    if (!data || (data.type !== "descriptors" && data.type !== "error")) return;
+    const entry = pending.get(data.id);
+    if (!entry) return;
+    pending.delete(data.id);
+    if (data.type === "descriptors") entry.resolve(data.descriptors);
+    else entry.reject(new Error(data.error));
+  });
+  worker.addEventListener("error", (event) => {
+    // An uncaught worker error can't be tied to a single request — fail every
+    // outstanding one so callers don't hang.
+    const error = new Error(
+      `module-loader worker error: ${event.message ?? "unknown"}`
+    );
+    for (const [, entry] of pending) entry.reject(error);
+    pending.clear();
+  });
+  return worker;
+}
+
+/** Ask the worker which plugins the package at `urlAtHeads` exports. */
+function discoverDescriptors(urlAtHeads: AutomergeUrl): Promise<Descriptor[]> {
+  const id = nextRequestId++;
+  return new Promise<Descriptor[]>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    getWorker().postMessage({ type: "discover", id, url: urlAtHeads });
+  });
+}
+
+/**
+ * ModuleWatcher `importAutomergeModule` hook: discover descriptors in the
+ * worker, then return the `{ plugins }` shape with a main-thread `load()` per
+ * plugin that imports the package at heads and calls its real loader.
+ */
+export async function importAutomergeModuleViaWorker(
+  urlAtHeads: string
+): Promise<{ plugins: Descriptor[] }> {
+  const url = urlAtHeads as AutomergeUrl;
+  const descriptors = await discoverDescriptors(url);
+  const plugins = descriptors.map((descriptor) => {
+    const id = descriptor.id;
+    if (typeof id !== "string") return descriptor;
+    return {
+      ...descriptor,
+      load: () => importPluginFromFolderDocUrl(url, id),
+    };
+  });
+  return { plugins };
+}

--- a/core/bootloader/src/module-loader.ts
+++ b/core/bootloader/src/module-loader.ts
@@ -10,7 +10,7 @@
 import { importPluginFromFolderDocUrl } from "@inkandswitch/patchwork-filesystem";
 import type { AutomergeUrl } from "@automerge/automerge-repo/slim";
 
-type Descriptor = Record<string, unknown> & { id?: string };
+type Descriptor = Record<string, unknown> & { id?: string; type?: string };
 
 type WorkerReply =
   | { type: "descriptors"; id: number; descriptors: Descriptor[] }
@@ -72,11 +72,13 @@ export async function importAutomergeModuleViaWorker(
   const url = urlAtHeads as AutomergeUrl;
   const descriptors = await discoverDescriptors(url);
   const plugins = descriptors.map((descriptor) => {
-    const id = descriptor.id;
-    if (typeof id !== "string") return descriptor;
+    const { id, type } = descriptor;
+    // A plugin id is only unique within a plugin type, so both are needed to
+    // re-select the right plugin when its load() re-imports the package.
+    if (typeof id !== "string" || typeof type !== "string") return descriptor;
     return {
       ...descriptor,
-      load: () => importPluginFromFolderDocUrl(url, id),
+      load: () => importPluginFromFolderDocUrl(url, type, id),
     };
   });
   return { plugins };

--- a/core/bootloader/src/site.ts
+++ b/core/bootloader/src/site.ts
@@ -49,6 +49,7 @@ const useKeyhiveSyncServer =
   typeof __KEYHIVE_SYNC_SERVER__ !== "undefined" && __KEYHIVE_SYNC_SERVER__;
 
 import { ModuleWatcher } from "@inkandswitch/patchwork-filesystem";
+import { importAutomergeModuleViaWorker } from "./module-loader.js";
 import {
   openDocument,
   registerPatchworkViewElement,
@@ -285,7 +286,10 @@ export async function bootPatchworkSite(
     repo,
     buildSystemSources(defaultModuleSources),
     onModuleLoaded,
-    unregisterPlugins
+    unregisterPlugins,
+    // Discover an Automerge package's plugin descriptors off the main thread;
+    // each plugin's load() re-imports the package (at heads) on this thread.
+    importAutomergeModuleViaWorker
   );
 
   const accountDocHandle = (await resolveAccountHandle(repo, {

--- a/core/bootloader/src/vite/service-worker-plugin.ts
+++ b/core/bootloader/src/vite/service-worker-plugin.ts
@@ -14,6 +14,10 @@ const workers = [
     specifier: "@inkandswitch/patchwork-bootloader/automerge-worker",
     fileName: "automerge-worker.js",
   },
+  {
+    specifier: "@inkandswitch/patchwork-bootloader/module-loader-worker",
+    fileName: "module-loader-worker.js",
+  },
 ];
 
 export function serviceworker(): Plugin {

--- a/core/filesystem/src/module-watcher.ts
+++ b/core/filesystem/src/module-watcher.ts
@@ -4,7 +4,6 @@ import {
   type DocumentId,
   isValidAutomergeUrl,
   type Repo,
-  stringifyAutomergeUrl,
 } from "@automerge/automerge-repo/slim";
 import { importModuleFromFolderDocUrl } from "./packages.js";
 import { getType, type HasPatchworkMetadata } from "./metadata.js";
@@ -90,17 +89,28 @@ export class ModuleWatcher {
 
   onLoad: (name: string, mod: any) => void;
   onUnload?: (name: string) => void;
+  /**
+   * How an Automerge folder-doc module (pinned to heads) is turned into the
+   * `{ plugins }` shape `onLoad` consumes. Defaults to importing the package
+   * entry point directly on this thread. The browser bootloader overrides this
+   * to run the entry point in a worker for descriptor discovery and rebuild the
+   * `{ plugins }` shape with main-thread `load()` functions.
+   */
+  importAutomergeModule: (urlAtHeads: string) => Promise<any>;
 
   constructor(
     repo: Repo,
     urls: Record<string, string>,
     callback: (name: string, mod: any) => void,
-    onUnload?: (name: string) => void
+    onUnload?: (name: string) => void,
+    importAutomergeModule: (urlAtHeads: string) => Promise<any> = (url) =>
+      importModuleFromFolderDocUrl(url as AutomergeUrl)
   ) {
     this.repo = repo;
     this.urls = { ...urls };
     this.onLoad = callback;
     this.onUnload = onUnload;
+    this.importAutomergeModule = importAutomergeModule;
     this.doneLoading = this.init();
   }
 
@@ -247,23 +257,14 @@ export class ModuleWatcher {
 
   private async importModuleSafe(importName: string): Promise<any | null> {
     try {
-      const valid = isValidAutomergeUrl(importName);
-
-      if (valid) {
+      if (isValidAutomergeUrl(importName)) {
+        // Pin to heads so descriptor discovery and any later main-thread load
+        // resolve against the exact same version of the folder doc.
         const handle = await this.repo.find(importName as AutomergeUrl);
-        importName = stringifyAutomergeUrl({
-          documentId: handle.documentId,
-          heads: handle.heads(),
-        });
-        importName = handle.view(handle.heads()).url;
-      } else {
-        return import(importName)
+        const urlAtHeads = handle.view(handle.heads()).url;
+        return await this.importAutomergeModule(urlAtHeads);
       }
-
-      const mod = valid
-        ? importModuleFromFolderDocUrl(importName as AutomergeUrl)
-        : import(/* @vite-ignore */ importName);
-      return mod;
+      return await import(/* @vite-ignore */ importName);
     } catch (error) {
       console.error(
         `%c Failed to import ${importName}`,

--- a/core/filesystem/src/packages.ts
+++ b/core/filesystem/src/packages.ts
@@ -46,7 +46,12 @@ export async function importModuleFromFolderDocUrl(
 /**
  * Import the entry point of a package (at `folderDocUrl`, which should be
  * pinned to heads) and return the loaded implementation of a single one of the
- * plugins it exports, selected by `pluginId`.
+ * plugins it exports, selected by its `pluginType` and `pluginId`.
+ *
+ * A plugin `id` is only unique *within* a plugin type (there is a separate
+ * registry per type), so a package can export e.g. a `patchwork:datatype` and
+ * a `patchwork:tool` that both have id `"x"`. Both `type` and `id` are needed
+ * to pick out the right one.
  *
  * This is the main-thread counterpart to discovering a package's plugin
  * descriptors in a worker: the worker reports *which* plugins a package
@@ -57,16 +62,19 @@ export async function importModuleFromFolderDocUrl(
  */
 export async function importPluginFromFolderDocUrl(
   folderDocUrl: AutomergeUrl,
+  pluginType: string,
   pluginId: string,
   subpath: string = ".",
   conditions: string[] = defaultImportConditions
 ) {
   const mod = await importModuleFromFolderDocUrl(folderDocUrl, subpath, conditions);
   const plugins: any[] = Array.isArray(mod?.plugins) ? mod.plugins : [];
-  const plugin = plugins.find((p) => p?.id === pluginId);
+  const plugin = plugins.find(
+    (p) => p?.type === pluginType && p?.id === pluginId
+  );
   if (!plugin) {
     throw new Error(
-      `No plugin "${pluginId}" exported by the package at ${folderDocUrl}`
+      `No plugin "${pluginType}:${pluginId}" exported by the package at ${folderDocUrl}`
     );
   }
   if (typeof plugin.load === "function") {
@@ -76,7 +84,7 @@ export async function importPluginFromFolderDocUrl(
     return import(/* @vite-ignore */ plugin.import);
   }
   throw new Error(
-    `Plugin "${pluginId}" at ${folderDocUrl} has no load() function or import URL`
+    `Plugin "${pluginType}:${pluginId}" at ${folderDocUrl} has no load() function or import URL`
   );
 }
 

--- a/core/filesystem/src/packages.ts
+++ b/core/filesystem/src/packages.ts
@@ -10,12 +10,14 @@ export const defaultImportConditions = ["patchwork", "browser", "import"];
 // is the string "null" inside a srcdoc/sandboxed frame — an invalid URL base —
 // whereas `document.baseURI` is the document's proper base URL (the embedder's
 // URL for a srcdoc frame, and the page URL for a normal document), so its origin
-// is valid in both cases.
+// is valid in both cases. Reached via `globalThis` so this also works inside a
+// worker (where `document`/`window` are undefined but `self.location` is the
+// site origin the service worker serves module URLs from).
 function documentBaseOrigin(): string {
   try {
-    return new URL(document.baseURI).origin;
+    return new URL(globalThis.document.baseURI).origin;
   } catch {
-    return window.location.origin;
+    return globalThis.location.origin;
   }
 }
 
@@ -39,6 +41,43 @@ export async function importModuleFromFolderDocUrl(
   log(`importing ${entryPointUrl.slice(-60)}`);
 
   return await import(/* @vite-ignore */ entryPointUrl);
+}
+
+/**
+ * Import the entry point of a package (at `folderDocUrl`, which should be
+ * pinned to heads) and return the loaded implementation of a single one of the
+ * plugins it exports, selected by `pluginId`.
+ *
+ * This is the main-thread counterpart to discovering a package's plugin
+ * descriptors in a worker: the worker reports *which* plugins a package
+ * exports, and this re-imports the package here to actually run the plugin's
+ * own `load()` / `import` — mirroring what {@link PluginRegistry.load} would do
+ * with the live descriptor, so the registered description and the loaded
+ * implementation come from the same pinned version.
+ */
+export async function importPluginFromFolderDocUrl(
+  folderDocUrl: AutomergeUrl,
+  pluginId: string,
+  subpath: string = ".",
+  conditions: string[] = defaultImportConditions
+) {
+  const mod = await importModuleFromFolderDocUrl(folderDocUrl, subpath, conditions);
+  const plugins: any[] = Array.isArray(mod?.plugins) ? mod.plugins : [];
+  const plugin = plugins.find((p) => p?.id === pluginId);
+  if (!plugin) {
+    throw new Error(
+      `No plugin "${pluginId}" exported by the package at ${folderDocUrl}`
+    );
+  }
+  if (typeof plugin.load === "function") {
+    return plugin.load();
+  }
+  if (typeof plugin.import === "string") {
+    return import(/* @vite-ignore */ plugin.import);
+  }
+  throw new Error(
+    `Plugin "${pluginId}" at ${folderDocUrl} has no load() function or import URL`
+  );
 }
 
 async function packageJsonContentsFromFolderDocUrl(


### PR DESCRIPTION
runs the initial index.js import in a worker
sends the plugins array back
replaces the load function in the plugin registry with one that imports-then-loads

visiting the module-settings-manager page will currently still import all your packages, so that probably needs separate work

(#301)