### PR TITLE
Log worker and tab lifecycle (for connection timeout debugging)

### DIFF
--- a/core/bootloader/src/automerge-worker.ts
+++ b/core/bootloader/src/automerge-worker.ts
@@ -54,6 +54,12 @@ declare const __KEYHIVE_SYNC_SERVER__: boolean;
 
 let debugging = false;
 
+// Per-boot identity so a tab can detect a worker *restart*: a fresh instance
+// means a new repo peerId + cold in-memory state, so the tab's docs must be
+// re-subscribed. Sent in `hello` (on connect) and every `pong`.
+const WORKER_INSTANCE_ID = Math.random().toString(36).slice(2);
+const WORKER_BOOT_TIME = Date.now();
+
 // ── Forward console output + uncaught errors to the main thread ─────────
 // The SharedWorker has its own console that's a pain to find (chrome://inspect
 // → shared workers). Patch console.* and the global error handlers to also
@@ -115,6 +121,35 @@ self.addEventListener("unhandledrejection", (event) => {
     reason instanceof Error ? reason.stack || reason.message : reason,
   ]);
 });
+
+// Boot marker, buffered until the first tab connects. A new instance id means
+// the worker restarted (fresh peerId + cold state).
+console.warn(
+  `[lifecycle] ${new Date(WORKER_BOOT_TIME).toISOString()} automerge ` +
+    `SharedWorker started (instance ${WORKER_INSTANCE_ID})`
+);
+
+// ── Suspension watchdog ─────────────────────────────────────────────────
+// A SharedWorker gets no lifecycle events, so infer freeze/suspend from timer
+// drift. A large gap means keepalive pongs stalled and the server may have
+// reaped us.
+const WATCHDOG_TICK_MS = 5_000;
+const WATCHDOG_GAP_FACTOR = 2;
+let watchdogLast = Date.now();
+setInterval(() => {
+  const now = Date.now();
+  const gap = now - watchdogLast;
+  watchdogLast = now;
+  if (gap > WATCHDOG_TICK_MS * WATCHDOG_GAP_FACTOR) {
+    console.warn(
+      `[lifecycle] worker resumed after ~${Math.round(gap / 1000)}s gap ` +
+        `(timer expected every ${WATCHDOG_TICK_MS / 1000}s) — likely ` +
+        `suspended/frozen/throttled; WebSocket keepalive pongs were not sent ` +
+        `during this window, so the sync server may have reaped us. at ` +
+        `${new Date(now).toISOString()}`
+    );
+  }
+}, WATCHDOG_TICK_MS);
 
 // Sync server selection. Sub is the default. Build with KEYHIVE_SYNC_SERVER=true
 // to target keyhive.sync.automerge.org.
@@ -424,6 +459,13 @@ function handleControlMessage(
         });
         replyPort?.close();
       });
+  } else if (data?.type === "ping") {
+    // Heartbeat: reply so the tab can detect our death or restart.
+    controlPort.postMessage({
+      type: "pong",
+      id: data.id,
+      instanceId: WORKER_INSTANCE_ID,
+    });
   }
 }
 
@@ -443,6 +485,14 @@ self.addEventListener("connect", (event) => {
   });
 
   controlPort.start();
+
+  // Greet the tab with our per-boot instance id so it can detect a restart
+  // (a different id than last seen) even if no port "close" fired.
+  controlPort.postMessage({
+    type: "hello",
+    instanceId: WORKER_INSTANCE_ID,
+    bootTime: WORKER_BOOT_TIME,
+  });
 
   // Start forwarding console output to this tab, and flush anything buffered
   // while no tab was connected (e.g. boot-time logs) to the first arrival.

--- a/core/bootloader/src/service-worker.ts
+++ b/core/bootloader/src/service-worker.ts
@@ -33,7 +33,49 @@ function log(...args: any[]) {
   );
 }
 
+// ── Lifecycle diagnostics ──────────────────────────────────────────────
+// [lifecycle] markers for SW (re)boots, install/activate, crashes, and stranded
+// handoffs. The SW can't read localStorage, so it always emits and forwards to
+// the tab, which gates rendering on the live toggle. The SW holds no sync
+// socket — observability only.
+
+async function postToClients(message: unknown) {
+  const clients = await self.clients.matchAll({
+    type: "window",
+    includeUncontrolled: true,
+  });
+  for (const client of clients) client.postMessage(message);
+}
+
+function lifecycle(level: "info" | "warn", text: string) {
+  const msg = `[lifecycle] ${new Date().toISOString()} ${text}`;
+  console[level](msg);
+  void postToClients({ type: "sw-lifecycle", level, msg });
+}
+
+lifecycle("info", `booted (scope ${self.registration?.scope ?? "?"})`);
+
+self.addEventListener("error", (event) => {
+  const e = event as ErrorEvent;
+  lifecycle(
+    "warn",
+    `uncaught error: ${e.message}` +
+      (e.filename ? ` @ ${e.filename}:${e.lineno}:${e.colno}` : "")
+  );
+});
+
+self.addEventListener("unhandledrejection", (event) => {
+  const reason = (event as PromiseRejectionEvent).reason;
+  lifecycle(
+    "warn",
+    `unhandled rejection: ${
+      reason instanceof Error ? reason.stack || reason.message : String(reason)
+    }`
+  );
+});
+
 self.addEventListener("install", (event) => {
+  lifecycle("info", "install (skipWaiting)");
   // waitUntil keeps the worker alive until skipWaiting resolves, so a freshly
   // installed SW reliably jumps the "waiting" queue instead of stalling until
   // every old tab closes.
@@ -52,6 +94,7 @@ async function clearOldCaches() {
 }
 
 self.addEventListener("activate", (event) => {
+  lifecycle("info", "activate (claiming clients)");
   (event as ExtendableEvent).waitUntil(
     (async () => {
       await clearOldCaches();
@@ -118,7 +161,15 @@ handoffChannel.addEventListener("message", (event) => {
   } else if (data?.type === "online") {
     // The automerge worker (re)started — re-broadcast anything still in
     // flight so requests that raced its boot aren't stranded.
-    for (const { message } of pendingHandoffs.values()) {
+    const stranded = [...pendingHandoffs.values()];
+    if (stranded.length > 0) {
+      lifecycle(
+        "info",
+        `automerge worker (re)started; re-broadcasting ${stranded.length} ` +
+          `in-flight asset handoff(s)`
+      );
+    }
+    for (const { message } of stranded) {
       log(`re-broadcasting handoff ${message.id} to the fresh worker`);
       handoffChannel.postMessage(message);
     }
@@ -148,6 +199,11 @@ function handoff(
   log(`broadcasting handoff request for cache ${cachename}`, message);
   handoffChannel.postMessage(message);
   const timeout = setTimeout(() => {
+    lifecycle(
+      "warn",
+      `asset handoff ${id} stranded: no reply from the automerge worker after ` +
+        `${HANDOFF_TIMEOUT_MS}ms (${handoffURL.href})`
+    );
     resolvers.reject(
       new Error(
         `no reply from the automerge worker after ${HANDOFF_TIMEOUT_MS}ms`

--- a/core/bootloader/src/setup.ts
+++ b/core/bootloader/src/setup.ts
@@ -12,6 +12,34 @@ import debug from "debug";
 const serviceWorkerDebugging = debug.enabled("patchwork:serviceworker");
 const workerDebugging = debug.enabled("patchwork:automergeworker");
 
+// Diagnostic [lifecycle] logging, on by default. Disable via
+// localStorage["patchwork:lifecycle-logs"] = "off". Read live at log time.
+const LIFECYCLE_LOG_KEY = "patchwork:lifecycle-logs";
+export function lifecycleLoggingEnabled(): boolean {
+  try {
+    const v = globalThis.localStorage?.getItem(LIFECYCLE_LOG_KEY);
+    return v !== "off" && v !== "false" && v !== "0" && v !== "no";
+  } catch {
+    return true;
+  }
+}
+
+// The SW can't read localStorage, so it always emits [lifecycle] markers and
+// forwards them as `sw-lifecycle`; gate rendering here on the live toggle.
+let swLifecycleListenerInstalled = false;
+function installServiceWorkerLogForwarding(): void {
+  if (swLifecycleListenerInstalled) return;
+  if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
+  swLifecycleListenerInstalled = true;
+  navigator.serviceWorker.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data;
+    if (data?.type !== "sw-lifecycle") return;
+    if (!lifecycleLoggingEnabled()) return;
+    const fn = (console as any)[data.level] ?? console.log;
+    fn(`[service-worker] ${data.msg}`);
+  });
+}
+
 const key = "patchworkServiceWorkerCacheVersion";
 let nextRepoChannelId = 0;
 
@@ -81,6 +109,14 @@ export function getAutomergeWorker(): SharedWorker {
     automergeWorker.port.addEventListener("message", (event: MessageEvent) => {
       if (event.data?.type !== "console") return;
       const { level, args } = event.data;
+      // Gate forwarded [lifecycle] logs on the toggle too.
+      if (
+        !lifecycleLoggingEnabled() &&
+        typeof args?.[0] === "string" &&
+        args[0].includes("[lifecycle]")
+      ) {
+        return;
+      }
       const fn = (console as any)[level] ?? console.log;
       // The worker's logs (debug library, the worker's own log()) carry %c
       // format directives in args[0] with CSS in the following args. Prefix
@@ -93,8 +129,80 @@ export function getAutomergeWorker(): SharedWorker {
       }
     });
     automergeWorker.port.postMessage({ type: "debug", debug: workerDebugging });
+
+    installWorkerDeathDetection(automergeWorker);
   }
   return automergeWorker;
+}
+
+/**
+ * Detect when the automerge SharedWorker dies or restarts: control-port close,
+ * worker error, changed instance id, or an unanswered heartbeat while the tab
+ * is visible (a miss while hidden is more likely suspension). [lifecycle]-tagged.
+ */
+function installWorkerDeathDetection(worker: SharedWorker): void {
+  const stamp = () => new Date().toISOString();
+  const warn = (msg: string) => {
+    if (lifecycleLoggingEnabled()) console.warn(`[lifecycle] ${stamp()} ${msg}`);
+  };
+  const info = (msg: string) => {
+    if (lifecycleLoggingEnabled()) console.info(`[lifecycle] ${stamp()} ${msg}`);
+  };
+
+  let instanceId: string | undefined;
+  let lastPongAt = Date.now();
+  let warnedUnresponsive = false;
+
+  worker.port.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data;
+    if (data?.type !== "hello" && data?.type !== "pong") return;
+    if (data.type === "pong") {
+      lastPongAt = Date.now();
+      warnedUnresponsive = false;
+    }
+    if (instanceId === undefined) {
+      instanceId = data.instanceId;
+      info(`automerge SharedWorker instance ${data.instanceId} (via ${data.type})`);
+    } else if (data.instanceId && data.instanceId !== instanceId) {
+      warn(
+        `automerge SharedWorker RESTARTED (instance ${data.instanceId}, ` +
+          `was ${instanceId}) — fresh peerId + cold state; docs need re-subscribe`
+      );
+      instanceId = data.instanceId;
+    }
+  });
+
+  // Fires when the SharedWorker is destroyed (where supported).
+  worker.port.addEventListener("close", () => {
+    warn("automerge SharedWorker control port CLOSED — worker terminated");
+  });
+
+  worker.addEventListener("error", event => {
+    warn(`automerge SharedWorker error: ${(event as ErrorEvent).message || event}`);
+  });
+
+  // A missed pong while the tab is visible means the worker likely died (an
+  // active tab keeps it alive); a miss while hidden is more likely suspension.
+  const HEARTBEAT_MS = 10_000;
+  const HEARTBEAT_TIMEOUT_MS = 25_000;
+  let seq = 0;
+  setInterval(() => {
+    try {
+      worker.port.postMessage({ type: "ping", id: ++seq });
+    } catch {
+      // Port already torn down — the "close" handler covers that case.
+    }
+    const silentMs = Date.now() - lastPongAt;
+    const visible =
+      typeof document === "undefined" || document.visibilityState === "visible";
+    if (silentMs > HEARTBEAT_TIMEOUT_MS && visible && !warnedUnresponsive) {
+      warnedUnresponsive = true;
+      warn(
+        `automerge SharedWorker UNRESPONSIVE ~${Math.round(silentMs / 1000)}s ` +
+          `while tab visible — likely died/crashed`
+      );
+    }
+  }, HEARTBEAT_MS);
 }
 
 export function connectClassicSync(
@@ -200,6 +308,10 @@ function getRepoChannel(): MessagePort {
 export default async function setupServiceWorker(
   options?: SetupServiceWorkerOptions
 ): Promise<SetupServiceWorkerResult> {
+  // Attach the SW→tab [lifecycle] log bridge as early as possible so boot /
+  // install / activate markers from the controlling worker are rendered here.
+  installServiceWorkerLogForwarding();
+
   if (options?.workerPath) automergeWorkerPath = options.workerPath;
 
   // Start the automerge worker right away so it boots (wasm, repo) while the

--- a/core/bootloader/src/site.ts
+++ b/core/bootloader/src/site.ts
@@ -65,7 +65,10 @@ import {
 } from "@inkandswitch/patchwork-plugins";
 import * as plugins from "@inkandswitch/patchwork-plugins";
 
-import setupServiceWorker, { getAutomergeWorker } from "./setup.js";
+import setupServiceWorker, {
+  getAutomergeWorker,
+  lifecycleLoggingEnabled,
+} from "./setup.js";
 import type { ServiceWorkerRepoChannelListener } from "./types.js";
 import debug from "debug";
 const log = debug("patchwork:bootloader:site");
@@ -181,6 +184,7 @@ export async function bootPatchworkSite(
   const defaultModuleSources = resolveDefaultModules(config);
   showLoadingAnimation();
   log(`booting`, config);
+  installLifecycleLogging();
   await initializeWasm(automergeWasm);
   initSubductionSync(subductionWasm);
 
@@ -402,6 +406,46 @@ function installDevConsoleGlobals(
     window.hive = hive;
   }
   window.getRepoChannel = getRepoChannel;
+}
+
+/**
+ * Log this tab's Page Lifecycle + connectivity transitions (visibility,
+ * freeze, bfcache, online/offline) so they line up against the SharedWorker's
+ * sync-socket reaps. [lifecycle]-tagged, on by default.
+ */
+function installLifecycleLogging(): void {
+  if (typeof document === "undefined") return;
+  const opts = { capture: true } as const;
+  const note = (label: string, extra?: unknown) => {
+    if (!lifecycleLoggingEnabled()) return;
+    const msg = `[lifecycle] ${new Date().toISOString()} ${label}`;
+    if (extra === undefined) console.info(msg);
+    else console.info(msg, extra);
+  };
+
+  document.addEventListener(
+    "visibilitychange",
+    () => note(`visibilitychange → ${document.visibilityState}`),
+    opts
+  );
+  document.addEventListener("freeze", () => note("freeze (tab suspended)"), opts);
+  document.addEventListener("resume", () => note("resume (tab unsuspended)"), opts);
+  window.addEventListener(
+    "pageshow",
+    e => note("pageshow", { persisted: (e as PageTransitionEvent).persisted }),
+    opts
+  );
+  window.addEventListener(
+    "pagehide",
+    e => note("pagehide", { persisted: (e as PageTransitionEvent).persisted }),
+    opts
+  );
+  window.addEventListener("online", () => note("online"), opts);
+  window.addEventListener("offline", () => note("offline"), opts);
+
+  note(
+    `lifecycle logging installed (visibilityState=${document.visibilityState}, hasFocus=${document.hasFocus()})`
+  );
 }
 
 function onModuleLoaded(name: string, mod: any): void {

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769220798,
-        "narHash": "sha256-ulD8bbh5eV4rUH61JC4gS8Ik0R2hBEEyCom3f8w2vXE=",
+        "lastModified": 1780272363,
+        "narHash": "sha256-kNxu1wkCevxc2SASJ+QXCoOcEWz+On6tR+lYv/ZWMpo=",
         "ref": "refs/heads/main",
-        "rev": "6c72a70e0241a5af26ba664ab63f3e2d89c45cd0",
-        "revCount": 5,
+        "rev": "eba91ae4f4a48eedab31777ed817d3c593cee7a8",
+        "revCount": 6,
         "type": "git",
         "url": "https://codeberg.org/expede/nix-command-utils"
       },
@@ -24,11 +24,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -56,26 +56,26 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769089682,
-        "narHash": "sha256-9yA/LIuAVQq0lXelrZPjLuLVuZdm03p8tfmHhnDIkms=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "type": "indirect"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1781216227,
-        "narHash": "sha256-9mUW6gNwoN2SWc/l0fW4svPNOulXLl8ijqKyeSOGgJE=",
+        "lastModified": 1782535326,
+        "narHash": "sha256-ZeRxu4yn6shd3SNF5ZUQb4r7BaVo1zBKMjRhfoNSBmw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a0374025a863d007d98e3297f6aa46cc3141c2f0",
+        "rev": "714a5f8c4ead6b31148d829288440ed033ccc041",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
To help diagnose why we're disconnecting from the server, this PR adds _default-enabled_ logs for shared worker and UI thread lifecycle information. We can make them quieter or opt-in later but I want them on by default to get started so that we capture this information when something goes wrong, not after a refresh when it may be fixed by a fresh connection :pray: 

(Was this vibe coded? Yep. But seems to print the data I'm interested in for this specific problem)