### PR TITLE
update to automerge-repo@2.6.0-subduction.45

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@automerge/automerge':
-      specifier: 3.3.1
-      version: 3.3.1
+      specifier: 3.3.2
+      version: 3.3.2
     '@types/react':
       specifier: 18.3.1
       version: 18.3.1
@@ -23,7 +23,7 @@ catalogs:
       version: 18.3.1
 
 overrides:
-  '@automerge/automerge-repo': 2.6.0-subduction.45
+  '@automerge/automerge-repo': 2.6.0-subduction.46
   '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.8b
   '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.45
   '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45
@@ -47,8 +47,8 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -84,10 +84,10 @@ importers:
     dependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
-        version: 3.3.1
+        version: 3.3.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-network-messagechannel':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45
@@ -151,8 +151,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-keyhive':
         specifier: 0.3.0-alpha.sub.8b
         version: 0.3.0-alpha.sub.8b(ws@8.21.0)
@@ -187,8 +187,8 @@ importers:
         specifier: '*'
         version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@types/debug':
         specifier: ^4.1.13
         version: 4.1.13
@@ -232,10 +232,10 @@ importers:
     devDependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
-        version: 3.3.1
+        version: 3.3.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-keyhive':
         specifier: 0.3.0-alpha.sub.8b
         version: 0.3.0-alpha.sub.8b(ws@8.21.0)
@@ -259,10 +259,10 @@ importers:
     devDependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
-        version: 3.3.1
+        version: 3.3.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -276,8 +276,8 @@ importers:
   packages/providers/core:
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -289,8 +289,8 @@ importers:
         version: link:../../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-react-hooks':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -311,8 +311,8 @@ importers:
         version: link:../../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-solid-primitives':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45(@automerge/automerge@3.3.1)(solid-js@1.9.13)
@@ -354,8 +354,8 @@ importers:
         version: link:../../core/plugins
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-solid-primitives':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45(@automerge/automerge@3.3.1)(solid-js@1.9.13)
@@ -370,10 +370,10 @@ importers:
     dependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
-        version: 3.3.1
+        version: 3.3.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-network-messagechannel':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45
@@ -455,10 +455,10 @@ importers:
     dependencies:
       '@automerge/automerge':
         specifier: 'catalog:'
-        version: 3.3.1
+        version: 3.3.2
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.45
-        version: 2.6.0-subduction.45
+        specifier: 2.6.0-subduction.46
+        version: 2.6.0-subduction.46
       '@automerge/automerge-repo-network-messagechannel':
         specifier: 2.6.0-subduction.45
         version: 2.6.0-subduction.45
@@ -574,8 +574,8 @@ packages:
     resolution: {integrity: sha512-3HQKjEBoto5qWGXeZlvqp5j+gp6TGan/mAEibNtifa4azrnd79s0G60f9iXVOwVNLZaWJdif57QsbQjg6jjNgQ==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.45':
-    resolution: {integrity: sha512-PSv5q38ik94uu4frW+bdGQchcbSxm/bO1JyBauQuL2Q1VwdhgHGQHrpwKoGPZ2s+wL/6z3TIK4Y3xaHL3yL6kA==}
+  '@automerge/automerge-repo@2.6.0-subduction.46':
+    resolution: {integrity: sha512-5we6RIe67b6ymRV/+6nKfRJnFD4e8FsudG+haJC/eaYieA4ZBVqVeY4OstJbg4QjkPhQe9VYYWa4HGHSPInYPw==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
@@ -583,6 +583,9 @@ packages:
 
   '@automerge/automerge@3.3.1':
     resolution: {integrity: sha512-ZnVHlUCPB9w3CFlqWe/ex2q3JIpJ5g0jAlxpX4NxHpjad/WwnyeUM3hQC+IrPO1P5kPX18agxesnXBVUA/qlvg==}
+
+  '@automerge/automerge@3.3.2':
+    resolution: {integrity: sha512-9vCdCL7pdQwUra66SBxPVHr+/t9epXKni9KDeak2rNBFMzABVh2u6gSpcwxi3jkR5qr047jVqZv9DlrOfVxLFw==}
 
   '@automerge/vanillajs@2.6.0-subduction.45':
     resolution: {integrity: sha512-gaB5vR5WPOFIuQF2L689GxAlMDWoCOvgK+wn6bSeSL0W7IyrHS1l/P1ZfDpHycuJ40ICNql23blFk0Yv2Fbp5Q==}
@@ -2663,7 +2666,7 @@ snapshots:
 
   '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.8b(ws@8.21.0)':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45
       '@automerge/automerge-subduction': 0.16.0
       '@keyhive/keyhive': 0.1.0-alpha.5
@@ -2679,7 +2682,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2687,7 +2690,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
       eventemitter3: 5.0.4
     transitivePeerDependencies:
       - bufferutil
@@ -2696,7 +2699,7 @@ snapshots:
 
   '@automerge/automerge-repo-network-websocket@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
       cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.4
@@ -2709,7 +2712,7 @@ snapshots:
   '@automerge/automerge-repo-react-hooks@2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@automerge/automerge': 3.3.1
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
       eventemitter3: 5.0.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -2725,15 +2728,15 @@ snapshots:
 
   '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.45':
+  '@automerge/automerge-repo@2.6.0-subduction.46':
     dependencies:
-      '@automerge/automerge': 3.3.1
+      '@automerge/automerge': 3.3.2
       '@automerge/automerge-subduction': 0.16.0
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -2753,9 +2756,11 @@ snapshots:
 
   '@automerge/automerge@3.3.1': {}
 
+  '@automerge/automerge@3.3.2': {}
+
   '@automerge/vanillajs@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo': 2.6.0-subduction.46
       '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.45
       '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.45
       '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@automerge/automerge':
+      specifier: 3.3.1
+      version: 3.3.1
     '@types/react':
       specifier: 18.3.1
       version: 18.3.1
@@ -20,17 +23,16 @@ catalogs:
       version: 18.3.1
 
 overrides:
-  '@automerge/automerge': 3.3.0-fragments.2
-  '@automerge/automerge-repo': 2.6.0-subduction.44
+  '@automerge/automerge-repo': 2.6.0-subduction.45
   '@automerge/automerge-repo-keyhive': 0.3.0-alpha.sub.8b
-  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.44
-  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.44
-  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.44
-  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.44
-  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.44
+  '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.45
+  '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45
+  '@automerge/automerge-repo-react-hooks': 2.6.0-subduction.45
+  '@automerge/automerge-repo-solid-primitives': 2.6.0-subduction.45
+  '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.45
   '@automerge/automerge-subduction': 0.16.0
-  '@automerge/react': 2.6.0-subduction.44
-  '@automerge/vanillajs': 2.6.0-subduction.44
+  '@automerge/react': 2.6.0-subduction.45
+  '@automerge/vanillajs': 2.6.0-subduction.45
   '@keyhive/keyhive': 0.1.0-alpha.5
 
 importers:
@@ -45,8 +47,8 @@ importers:
         version: 18.3.1
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -81,26 +83,26 @@ importers:
   core/bootloader:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 'catalog:'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@inkandswitch/patchwork-elements':
         specifier: workspace:^
         version: link:../elements
@@ -149,8 +151,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-keyhive':
         specifier: 0.3.0-alpha.sub.8b
         version: 0.3.0-alpha.sub.8b(ws@8.21.0)
@@ -182,11 +184,11 @@ importers:
   core/filesystem:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: '*'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@types/debug':
         specifier: ^4.1.13
         version: 4.1.13
@@ -201,8 +203,8 @@ importers:
         version: 2.0.3
     devDependencies:
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -229,11 +231,11 @@ importers:
         version: 2.0.3
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 'catalog:'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-keyhive':
         specifier: 0.3.0-alpha.sub.8b
         version: 0.3.0-alpha.sub.8b(ws@8.21.0)
@@ -256,11 +258,11 @@ importers:
   packages/edge-handles:
     devDependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 'catalog:'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
@@ -274,8 +276,8 @@ importers:
   packages/providers/core:
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -287,11 +289,11 @@ importers:
         version: link:../../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.1
@@ -309,11 +311,11 @@ importers:
         version: link:../../core
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-solid-primitives':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(@automerge/automerge@3.3.0-fragments.2)(solid-js@1.9.13)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(@automerge/automerge@3.3.1)(solid-js@1.9.13)
       solid-js:
         specifier: ^1.9.13
         version: 1.9.13
@@ -324,11 +326,11 @@ importers:
   packages/react:
     devDependencies:
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@inkandswitch/patchwork-plugins':
         specifier: workspace:^
         version: link:../../core/plugins
@@ -352,11 +354,11 @@ importers:
         version: link:../../core/plugins
     devDependencies:
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-solid-primitives':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(@automerge/automerge@3.3.0-fragments.2)(solid-js@1.9.13)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(@automerge/automerge@3.3.1)(solid-js@1.9.13)
       solid-js:
         specifier: ^1.9.13
         version: 1.9.13
@@ -367,29 +369,29 @@ importers:
   sites/gaios:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 'catalog:'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@codemirror/commands':
         specifier: ^6.10.4
         version: 6.10.4
@@ -452,29 +454,29 @@ importers:
   sites/tiny-patchwork:
     dependencies:
       '@automerge/automerge':
-        specifier: 3.3.0-fragments.2
-        version: 3.3.0-fragments.2
+        specifier: 'catalog:'
+        version: 3.3.1
       '@automerge/automerge-repo':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-messagechannel':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-network-websocket':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-repo-react-hooks':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automerge/automerge-repo-storage-indexeddb':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@automerge/automerge-subduction':
         specifier: 0.16.0
         version: 0.16.0
       '@automerge/vanillajs':
-        specifier: 2.6.0-subduction.44
-        version: 2.6.0-subduction.44
+        specifier: 2.6.0-subduction.45
+        version: 2.6.0-subduction.45
       '@codemirror/commands':
         specifier: ^6.10.4
         version: 6.10.4
@@ -542,48 +544,48 @@ packages:
   '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.8b':
     resolution: {integrity: sha512-Ld97PHH3fn9i0vnctjobaQV61BYjhmDZloSpfrFmXl6ynOfe8VUG4b0AyMJjmrpT9Fwz51An4u8ICoUpDsyUJg==}
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.44':
-    resolution: {integrity: sha512-RJYE+QbSd3iDMMCxHTWobBTLU95w5Js+Qz9iWxFq/vpVJ9EnA+O1vT3ah39xwyooXTyjXOgCvz8QGMEZJ4nVnQ==}
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.45':
+    resolution: {integrity: sha512-HHzaFvfJhb0mttShk0LHrcwRbIhiOmeJnn4Ot6n8i+jJfX/dG6pf+NQ3yCHYeGbZUl80pjT/wWFH0Ey3IUKQdw==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.44':
-    resolution: {integrity: sha512-GHdzuqXMCiGC4vOSsK+n0c+hRxP0L0bbmp2byjvLg1XdB+ynGOxe2svU9Nz5AVydvMPTuOWYL+CiFmm9NzmOoA==}
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.45':
+    resolution: {integrity: sha512-ppnFX6v9YQFtBixAW8wmQocojui8L0noptx7UoC21w8chxFh15ut2bTJQUln3Zxo03NbaAQ8GrZgzg9G9+KTuA==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.44':
-    resolution: {integrity: sha512-JuUkcQNL122Iz5yd6wipAxQs1A4H7QddA4VZOAl3kWMhzYgE8Dv7SFMb9gd+1UWnZjoLOEbaYe7xPFV5UdcMMQ==}
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.45':
+    resolution: {integrity: sha512-Ad2qAEdn9b5AZRiggP78XGQ1WnSeekYzIUW7UTvKgIpkQ6kPCk/wtf74PSbRdWspRyZvurD3K5iK3LV8gz0PnA==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.44':
-    resolution: {integrity: sha512-4BFxqZt0VJJKq+boqHBHMP3pj0PnDF6DebIGwPYSP3Kn61OYbYk7iBveyEeazalWIqrzH35/4FVIqJKdaOnIGQ==}
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.45':
+    resolution: {integrity: sha512-AVa8MIVOHKn101ipvJinXpHuTshYcCRUyny6Q44siU9KV1II/khvm6yjUJn0uwwC7ewNkkPR/1Y9VOEn9zfiZw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.44':
-    resolution: {integrity: sha512-r6v7OPO3HPKNrI1wlTSgUGuSNeiWeQEb1XOkn2IkAjjwny/W5pS9eliVAEVM95mJVc3iJkD01d6EVbyLTGj5YQ==}
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.45':
+    resolution: {integrity: sha512-RscWGeBYHuSTkUBXnAsKoSMS+KHb5FE9doeJE3+TrVtMxcTlC3WfThic+y5kkgZUTCZ4QJH/ZjMVw1RLWlaLsg==}
     engines: {node: '>=22.13'}
     peerDependencies:
-      '@automerge/automerge': 3.3.0-fragments.2
+      '@automerge/automerge': ^3.0.0
       solid-js: ^1.9.4
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.44':
-    resolution: {integrity: sha512-39SgMMSzR7xMLQGcgL83O0AMjqV/Rl7nEiXuu35YxJNAdSwUiBUeUr8k7KDNvSV8yEBC35DzzDI2q40ALWvFsw==}
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.45':
+    resolution: {integrity: sha512-3HQKjEBoto5qWGXeZlvqp5j+gp6TGan/mAEibNtifa4azrnd79s0G60f9iXVOwVNLZaWJdif57QsbQjg6jjNgQ==}
     engines: {node: '>=22.13'}
 
-  '@automerge/automerge-repo@2.6.0-subduction.44':
-    resolution: {integrity: sha512-rx+PZS+adt1NaIoYxvphdy2yEVnuyRqQ3lVWqPomqrWBgRe5rbDCuVU4y6HW7/hVCInZzsZq/xtrDwjPMiHETw==}
+  '@automerge/automerge-repo@2.6.0-subduction.45':
+    resolution: {integrity: sha512-PSv5q38ik94uu4frW+bdGQchcbSxm/bO1JyBauQuL2Q1VwdhgHGQHrpwKoGPZ2s+wL/6z3TIK4Y3xaHL3yL6kA==}
     engines: {node: '>=22.13'}
 
   '@automerge/automerge-subduction@0.16.0':
     resolution: {integrity: sha512-BOOn/4p8cF4LhjDUQdgM3qyZFya+M7ZuZywuC99x/kbhk4UK7dw/QcsifcHG5E1TAW4R/K17ZGFUC5nCVUSSWg==}
 
-  '@automerge/automerge@3.3.0-fragments.2':
-    resolution: {integrity: sha512-F5KL+YXD0GMFH/as0/kJ3+lotpuJsH1SSrhhKdYSGtR+S9ytBNTw+s3pAjF2Vr0+ZdTMHxsGjqj5SRkJiSNokQ==}
+  '@automerge/automerge@3.3.1':
+    resolution: {integrity: sha512-ZnVHlUCPB9w3CFlqWe/ex2q3JIpJ5g0jAlxpX4NxHpjad/WwnyeUM3hQC+IrPO1P5kPX18agxesnXBVUA/qlvg==}
 
-  '@automerge/vanillajs@2.6.0-subduction.44':
-    resolution: {integrity: sha512-ddlJOlakRBOD2+C8xU8rjWWweSa3RGvVEIYtlhoVpg6zaSxM30QHCJ2A8a/U5xu9fMoLVbz4ghts3vZ84oky0w==}
+  '@automerge/vanillajs@2.6.0-subduction.45':
+    resolution: {integrity: sha512-gaB5vR5WPOFIuQF2L689GxAlMDWoCOvgK+wn6bSeSL0W7IyrHS1l/P1ZfDpHycuJ40ICNql23blFk0Yv2Fbp5Q==}
     engines: {node: '>=22.13'}
 
   '@babel/runtime@7.29.7':
@@ -2661,8 +2663,8 @@ snapshots:
 
   '@automerge/automerge-repo-keyhive@0.3.0-alpha.sub.8b(ws@8.21.0)':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45
       '@automerge/automerge-subduction': 0.16.0
       '@keyhive/keyhive': 0.1.0-alpha.5
       '@noble/hashes': 2.2.0
@@ -2675,26 +2677,26 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.44':
+  '@automerge/automerge-repo-network-broadcastchannel@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.44':
+  '@automerge/automerge-repo-network-messagechannel@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
       eventemitter3: 5.0.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.44':
+  '@automerge/automerge-repo-network-websocket@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
       cbor-x: 1.6.4
       debug: 4.4.3
       eventemitter3: 5.0.4
@@ -2704,10 +2706,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.44(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@automerge/automerge-repo-react-hooks@2.6.0-subduction.45(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.2
-      '@automerge/automerge-repo': 2.6.0-subduction.44
+      '@automerge/automerge': 3.3.1
+      '@automerge/automerge-repo': 2.6.0-subduction.45
       eventemitter3: 5.0.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -2716,22 +2718,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.44(@automerge/automerge@3.3.0-fragments.2)(solid-js@1.9.13)':
+  '@automerge/automerge-repo-solid-primitives@2.6.0-subduction.45(@automerge/automerge@3.3.1)(solid-js@1.9.13)':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.2
+      '@automerge/automerge': 3.3.1
       solid-js: 1.9.13
 
-  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.44':
+  '@automerge/automerge-repo-storage-indexeddb@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@automerge/automerge-repo@2.6.0-subduction.44':
+  '@automerge/automerge-repo@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge': 3.3.0-fragments.2
+      '@automerge/automerge': 3.3.1
       '@automerge/automerge-subduction': 0.16.0
       bs58check: 4.0.0
       cbor-x: 1.6.4
@@ -2749,15 +2751,15 @@ snapshots:
 
   '@automerge/automerge-subduction@0.16.0': {}
 
-  '@automerge/automerge@3.3.0-fragments.2': {}
+  '@automerge/automerge@3.3.1': {}
 
-  '@automerge/vanillajs@2.6.0-subduction.44':
+  '@automerge/vanillajs@2.6.0-subduction.45':
     dependencies:
-      '@automerge/automerge-repo': 2.6.0-subduction.44
-      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.44
-      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.44
-      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.44
-      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.44
+      '@automerge/automerge-repo': 2.6.0-subduction.45
+      '@automerge/automerge-repo-network-broadcastchannel': 2.6.0-subduction.45
+      '@automerge/automerge-repo-network-messagechannel': 2.6.0-subduction.45
+      '@automerge/automerge-repo-network-websocket': 2.6.0-subduction.45
+      '@automerge/automerge-repo-storage-indexeddb': 2.6.0-subduction.45
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,8 +27,8 @@ minimumReleaseAgeExclude:
   - "@chee/*"
 
 catalog:
-  "@automerge/automerge": 3.3.1
-  "@automerge/automerge-repo": 2.6.0-subduction.45
+  "@automerge/automerge": 3.3.2
+  "@automerge/automerge-repo": 2.6.0-subduction.46
   "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.8b
   "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.45
   "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.45

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ packages:
   - sites/*
 
 overrides:
-  "@automerge/automerge": "catalog:"
   "@automerge/automerge-repo": "catalog:"
   "@automerge/automerge-repo-keyhive": "catalog:"
   "@automerge/automerge-repo-network-messagechannel": "catalog:"
@@ -28,18 +27,18 @@ minimumReleaseAgeExclude:
   - "@chee/*"
 
 catalog:
-  "@automerge/automerge": 3.3.0-fragments.2
-  "@automerge/automerge-repo": 2.6.0-subduction.44
+  "@automerge/automerge": 3.3.1
+  "@automerge/automerge-repo": 2.6.0-subduction.45
   "@automerge/automerge-repo-keyhive": 0.3.0-alpha.sub.8b
-  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.44
-  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.44
-  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.44
-  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.44
-  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.44
-  "@automerge/automerge-repo-storage-nodefs": 2.6.0-subduction.44
+  "@automerge/automerge-repo-network-messagechannel": 2.6.0-subduction.45
+  "@automerge/automerge-repo-network-websocket": 2.6.0-subduction.45
+  "@automerge/automerge-repo-react-hooks": 2.6.0-subduction.45
+  "@automerge/automerge-repo-solid-primitives": 2.6.0-subduction.45
+  "@automerge/automerge-repo-storage-indexeddb": 2.6.0-subduction.45
+  "@automerge/automerge-repo-storage-nodefs": 2.6.0-subduction.45
   "@automerge/automerge-subduction": 0.16.0
-  "@automerge/react": 2.6.0-subduction.44
-  "@automerge/vanillajs": 2.6.0-subduction.44
+  "@automerge/react": 2.6.0-subduction.45
+  "@automerge/vanillajs": 2.6.0-subduction.45
   "@keyhive/keyhive": 0.1.0-alpha.5
   "@types/react": 18.3.1
   "@types/react-dom": 18.3.1


### PR DESCRIPTION
The headline here is that this updates to @automerge/automerge@3.3.1 which a) is an actual public release, not a pre-release and b) has a large number of bugfixes in it, including one rather nasty sync bug.