### PR TITLE
Update installation instructions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,13 @@ git clone https://github.com/inkandswitch/patchwork
 cd patchwork
 pnpm install
 pnpm build
-SITE=patchwork pnpm dev
+pnpm dev
 ```
+
+For a specific site run
+
+```shell
+SITE=tiny-patchwork pnpm dev
+```
+
+The development server will be running at [localhost:5173](http://localhost:5173/).


### PR DESCRIPTION
I wanted to clone the repo down for Automerge shenanigans and noticed the Readme installation instructions introduced in 8204f92530440dc760fb944bb50d7312d984a726 were incorrect. It does work with the changes in this PR and also adds a note on where the development server is running since it was a bit tricky to find in the logs.